### PR TITLE
feat(qa): fix wrong escape in graphql api call for qa

### DIFF
--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/chain.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/chain.py
@@ -277,7 +277,7 @@ def run_qa_agent_from_single_document_no_memory(input_params):
     status_variables['jobstatus'] = 'Done'
     status_variables['answer'] = llm_answer_base64_string
     status_variables['question'] = input_params['question']
-    status_variables['sources'] = filename
+    status_variables['sources'] = [filename]
     send_job_status(status_variables)
 
     response = {'question': input_params['question'], 'answer': answer, 'sources': input_params['filename'], 'filename': input_params['filename']}

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/helper.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/helper.py
@@ -82,7 +82,7 @@ def send_job_status(variables):
 
     query = """
     mutation updateQAJobStatus {
-        updateQAJobStatus (jobstatus: \"$jobstatus\", jobid: $jobid, answer: \""""+answer+"""\", question: \""""+question+"""\", filename: \"$filename\", sources: $sources) 
+        updateQAJobStatus (jobstatus: \"$jobstatus\", jobid: \"$jobid\", answer: \""""+answer+"""\", question: \""""+question+"""\", filename: \"$filename\", sources: $sources) 
         {
             jobstatus, 
             jobid, 
@@ -95,7 +95,7 @@ def send_job_status(variables):
 
     query = query.replace("$jobstatus", variables['jobstatus'])
     query = query.replace("$filename", variables['filename'])
-    query = query.replace("$jobid", str(variables['jobid']))
+    query = query.replace("$jobid", variables['jobid'])
     query = query.replace("$sources", str(variables['sources']).replace("\'", "\""))
 
     request = {'query':query}


### PR DESCRIPTION
Fixes #

fix a wrong escape in a case where an input file is provided which leads to incorrect result in subscription
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
