### PR TITLE
fix(constructs): fix log group name bug for step functions

### DIFF
--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -1,0 +1,55 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+import * as cdk from 'aws-cdk-lib';
+/**
+ * @internal This is an internal core function and should not be called directly by Solutions Constructs clients.
+ *
+ * @summary Creates a physical resource name in the style of the CDK (string+hash) - this value incorporates Stack ID,
+ * so it will remain static in multiple updates of a single stack, but will be different in a separate stack instance
+ * @param {string[]} parts - the various string components of the name (eg - stackName, solutions construct ID, L2 construct ID)
+ * @param {number} maxLength - the longest string that can be returned
+ * @returns {string} - a string with concatenated parts (truncated if necessary) + a hash of the full concatenated parts
+ *
+ */
+export function generatePhysicalName(
+    prefix: string,
+    parts: string[],
+    maxLength: number,
+  ): string {
+    // The result will consist of:
+    //    -The prefix - unaltered
+    //    -The parts concatenated, but reduced in size to meet the maxLength limit for the overall name
+    //    -A hyphen delimiter
+    //    -The GUID portion of the stack arn
+  
+    const stackIdGuidLength = 36;
+    const prefixLength = prefix.length;
+    const maxPartsLength = maxLength - prefixLength - 1 - stackIdGuidLength; // 1 is the hyphen
+  
+    // Extract the Stack ID Guid
+    const uniqueStackIdPart = cdk.Fn.select(2, cdk.Fn.split('/', `${cdk.Aws.STACK_ID}`));
+  
+    let allParts: string = '';
+  
+    parts.forEach((part) => {
+      allParts += part;
+    });
+  
+    if (allParts.length > maxPartsLength) {
+      const subStringLength = maxPartsLength / 2;
+      allParts = allParts.substring(0, subStringLength) + allParts.substring(allParts.length - subStringLength);
+    }
+  
+    const finalName  = prefix.toLowerCase() + allParts + '-' + uniqueStackIdPart;
+    return finalName;
+  }

--- a/src/common/helpers/utils.ts
+++ b/src/common/helpers/utils.ts
@@ -22,34 +22,34 @@ import * as cdk from 'aws-cdk-lib';
  *
  */
 export function generatePhysicalName(
-    prefix: string,
-    parts: string[],
-    maxLength: number,
-  ): string {
-    // The result will consist of:
-    //    -The prefix - unaltered
-    //    -The parts concatenated, but reduced in size to meet the maxLength limit for the overall name
-    //    -A hyphen delimiter
-    //    -The GUID portion of the stack arn
-  
-    const stackIdGuidLength = 36;
-    const prefixLength = prefix.length;
-    const maxPartsLength = maxLength - prefixLength - 1 - stackIdGuidLength; // 1 is the hyphen
-  
-    // Extract the Stack ID Guid
-    const uniqueStackIdPart = cdk.Fn.select(2, cdk.Fn.split('/', `${cdk.Aws.STACK_ID}`));
-  
-    let allParts: string = '';
-  
-    parts.forEach((part) => {
-      allParts += part;
-    });
-  
-    if (allParts.length > maxPartsLength) {
-      const subStringLength = maxPartsLength / 2;
-      allParts = allParts.substring(0, subStringLength) + allParts.substring(allParts.length - subStringLength);
-    }
-  
-    const finalName  = prefix.toLowerCase() + allParts + '-' + uniqueStackIdPart;
-    return finalName;
+  prefix: string,
+  parts: string[],
+  maxLength: number,
+): string {
+  // The result will consist of:
+  //    -The prefix - unaltered
+  //    -The parts concatenated, but reduced in size to meet the maxLength limit for the overall name
+  //    -A hyphen delimiter
+  //    -The GUID portion of the stack arn
+
+  const stackIdGuidLength = 36;
+  const prefixLength = prefix.length;
+  const maxPartsLength = maxLength - prefixLength - 1 - stackIdGuidLength; // 1 is the hyphen
+
+  // Extract the Stack ID Guid
+  const uniqueStackIdPart = cdk.Fn.select(2, cdk.Fn.split('/', `${cdk.Aws.STACK_ID}`));
+
+  let allParts: string = '';
+
+  parts.forEach((part) => {
+    allParts += part;
+  });
+
+  if (allParts.length > maxPartsLength) {
+    const subStringLength = maxPartsLength / 2;
+    allParts = allParts.substring(0, subStringLength) + allParts.substring(allParts.length - subStringLength);
   }
+
+  const finalName = prefix.toLowerCase() + allParts + '-' + uniqueStackIdPart;
+  return finalName;
+}

--- a/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
+++ b/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 import * as path from 'path';
-import { Duration, Aws } from 'aws-cdk-lib';
+import { Duration, Aws, Stack } from 'aws-cdk-lib';
 import * as appsync from 'aws-cdk-lib/aws-appsync';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
@@ -29,6 +29,7 @@ import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import * as s3_bucket_helper from '../../../common/helpers/s3-bucket-helper';
 import * as vpc_helper from '../../../common/helpers/vpc-helper';
+import { generatePhysicalName } from '../../../common/helpers/utils';
 
 /**
  * The properties for the RagAppsyncStepfnOpensearchProps class.
@@ -770,6 +771,19 @@ export class RagAppsyncStepfnOpensearch extends Construct {
     const definition = inputValidationTask.next(validate_input_choice.when(
       stepfn.Condition.booleanEquals('$.validation_result.Payload.isValid', false), jobFailed).otherwise(run_files_in_parallel.next(embeddingsTask)));
 
+    const maxLogGroupNameLength = 255;
+    const logGroupPrefix = '/aws/vendedlogs/states/constructs/';
+    const maxGeneratedNameLength = maxLogGroupNameLength - logGroupPrefix.length;
+    const nameParts: string[] = [
+      Stack.of(scope).stackName, // Name of the stack
+      scope.node.id,                 // Construct ID
+      'StateMachineLog'              // Literal string for log group name portion
+    ];
+    const logGroupName = generatePhysicalName(logGroupPrefix, nameParts, maxGeneratedNameLength);
+    const ragLogGroup = new logs.LogGroup(this, 'ingestionStepFunctionLogGroup', {
+      logGroupName: logGroupName
+    });
+
     const ingestion_step_function = new stepfn.StateMachine(
       this,
       'IngestionStateMachine',
@@ -778,7 +792,7 @@ export class RagAppsyncStepfnOpensearch extends Construct {
         definitionBody: stepfn.DefinitionBody.fromChainable(definition),
         timeout: Duration.minutes(30),
         logs: {
-          destination: new logs.LogGroup(this, 'ingestionStepFunctionLogGroup'),
+          destination: ragLogGroup,
           level: stepfn.LogLevel.ALL,
         },
         tracingEnabled: enable_xray,

--- a/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
+++ b/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
@@ -28,8 +28,8 @@ import * as stepfn_task from 'aws-cdk-lib/aws-stepfunctions-tasks';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import * as s3_bucket_helper from '../../../common/helpers/s3-bucket-helper';
-import * as vpc_helper from '../../../common/helpers/vpc-helper';
 import { generatePhysicalName } from '../../../common/helpers/utils';
+import * as vpc_helper from '../../../common/helpers/vpc-helper';
 
 /**
  * The properties for the RagAppsyncStepfnOpensearchProps class.
@@ -776,12 +776,12 @@ export class RagAppsyncStepfnOpensearch extends Construct {
     const maxGeneratedNameLength = maxLogGroupNameLength - logGroupPrefix.length;
     const nameParts: string[] = [
       Stack.of(scope).stackName, // Name of the stack
-      scope.node.id,                 // Construct ID
-      'StateMachineLog'              // Literal string for log group name portion
+      scope.node.id, // Construct ID
+      'StateMachineLog', // Literal string for log group name portion
     ];
     const logGroupName = generatePhysicalName(logGroupPrefix, nameParts, maxGeneratedNameLength);
     const ragLogGroup = new logs.LogGroup(this, 'ingestionStepFunctionLogGroup', {
-      logGroupName: logGroupName
+      logGroupName: logGroupName,
     });
 
     const ingestion_step_function = new stepfn.StateMachine(

--- a/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
+++ b/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
@@ -777,7 +777,7 @@ export class RagAppsyncStepfnOpensearch extends Construct {
     const nameParts: string[] = [
       Stack.of(scope).stackName, // Name of the stack
       scope.node.id, // Construct ID
-      'StateMachineLog', // Literal string for log group name portion
+      'StateMachineLogRag', // Literal string for log group name portion
     ];
     const logGroupName = generatePhysicalName(logGroupPrefix, nameParts, maxGeneratedNameLength);
     const ragLogGroup = new logs.LogGroup(this, 'ingestionStepFunctionLogGroup', {

--- a/src/patterns/gen-ai/aws-summarization-appsync-stepfn/index.ts
+++ b/src/patterns/gen-ai/aws-summarization-appsync-stepfn/index.ts
@@ -811,7 +811,7 @@ export class SummarizationAppsyncStepfn extends Construct {
     const nameParts: string[] = [
       Stack.of(scope).stackName, // Name of the stack
       scope.node.id, // Construct ID
-      'StateMachineLog', // Literal string for log group name portion
+      'StateMachineLogSummarization', // Literal string for log group name portion
     ];
     const logGroupName = generatePhysicalName(logGroupPrefix, nameParts, maxGeneratedNameLength);
     const summarizationLogGroup = new logs.LogGroup(this, 'summarizationLogGroup', {

--- a/src/patterns/gen-ai/aws-summarization-appsync-stepfn/index.ts
+++ b/src/patterns/gen-ai/aws-summarization-appsync-stepfn/index.ts
@@ -30,8 +30,8 @@ import { Construct } from 'constructs';
 import * as eventBridge from '../../../common/helpers/eventbridge-helper';
 import * as redisHelper from '../../../common/helpers/redis-helper';
 import * as s3BucketHelper from '../../../common/helpers/s3-bucket-helper';
-import * as vpcHelper from '../../../common/helpers/vpc-helper';
 import { generatePhysicalName } from '../../../common/helpers/utils';
+import * as vpcHelper from '../../../common/helpers/vpc-helper';
 
 export interface SummarizationAppsyncStepfnProps {
   /**
@@ -810,12 +810,12 @@ export class SummarizationAppsyncStepfn extends Construct {
     const maxGeneratedNameLength = maxLogGroupNameLength - logGroupPrefix.length;
     const nameParts: string[] = [
       Stack.of(scope).stackName, // Name of the stack
-      scope.node.id,                 // Construct ID
-      'StateMachineLog'              // Literal string for log group name portion
+      scope.node.id, // Construct ID
+      'StateMachineLog', // Literal string for log group name portion
     ];
     const logGroupName = generatePhysicalName(logGroupPrefix, nameParts, maxGeneratedNameLength);
     const summarizationLogGroup = new logs.LogGroup(this, 'summarizationLogGroup', {
-      logGroupName: logGroupName
+      logGroupName: logGroupName,
     });
 
     // step function definition


### PR DESCRIPTION
When tearing down/re-deploying a stack using the constructs, the user can face an issue where 
```
"Invalid Logging Configuration: The CloudWatch Logs Resource Policy size was exceeded. We suggest prefixing your CloudWatch log group name with /aws/vendedlogs/states/. (Service: AWSStepFunctions; Status Code: 400; Error Code: InvalidLoggingConfiguration; Request ID: ccf12a8e-30f5-4cc5-a4a2-627850477782; Proxy: null)" (RequestToken: 1a8e1d6a-162b-df56-7e6c-b04d222b7765, HandlerErrorCode: InvalidRequest)". 
```

This is related to an issue in IH where a log delivery policy is created (AWSLogDeliveryWrite*) and data are cumulated without being properly cleared. One way to workaround the issue is to prefix the name of the log group however that api [is not exposed](https://github.com/aws/aws-cdk/issues/19353) yet through CDK.

There is a great [solution](https://github.com/aws/aws-cdk/discussions/25257) proposed by @biffgaut and implemented in the [aws-solutions-constructs](https://github.com/awslabs/aws-solutions-constructs/blob/main/source/patterns/%40aws-solutions-constructs/core/lib/utils.ts) which we replicate here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
