### PR TITLE
chore: Raise langchain layers version (requirements.txt)

### DIFF
--- a/layers/langchain-common-deps/requirements.txt
+++ b/layers/langchain-common-deps/requirements.txt
@@ -1,7 +1,7 @@
-boto3>=1.28.69
-botocore>=1.31.69
+boto3>=1.34.6
+botocore>=1.34.6
 requests==2.31.0
 requests-aws4auth==1.2.3
-langchain==0.0.329
-opensearch-py==2.3.1
-openai==0.28.1
+langchain==0.0.351
+opensearch-py==2.4.2
+openai==1.6.0


### PR DESCRIPTION
Propose upgrading packages to adhere and align with current langchain documentation.

This is a breaking change for those using older langchain configurations. Documentation no longer supports 0.0.329

Fixes #

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
