### PR TITLE
fix: ts-jest configuration under globals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ __pycache__/
 !.ort.yml
 .idea
 .vscode
-!/.projenrc.js
 /test-reports/
 junit.xml
 /coverage/
@@ -65,3 +64,4 @@ tsconfig.json
 !/.github/workflows/semgrep.yml
 !/.github/workflows/bandit.yml
 !/.github/workflows/commitlint.yml
+!/.projenrc.ts

--- a/.npmignore
+++ b/.npmignore
@@ -36,3 +36,5 @@ header.js
 projenrc
 tsconfig.dev.json
 yarn.lock
+/.gitattributes
+/.projenrc.ts

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "projen",
-      "version": "~0.77.4",
+      "version": "~0.78.8",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -117,7 +117,8 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools projenrc .projenrc.ts"
+          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern $@ src test build-tools projenrc .projenrc.ts",
+          "receiveArgs": true
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -35,7 +35,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   authorOrganization: true,
   description: 'AWS Generative AI CDK Constructs is a library for well-architected generative AI patterns.',
   cdkVersion: CDK_VERSION,
-  projenVersion: '~0.77.4',
+  projenVersion: '~0.78.8',
   constructsVersion: '10.3.0',
   defaultReleaseBranch: 'main',
   jsiiVersion: '~5.1.0',

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jsii-diff": "^1.93.0",
     "jsii-pacmak": "^1.93.0",
     "jsii-rosetta": "~5.1.0",
-    "projen": "~0.77.4",
+    "projen": "~0.78.8",
     "standard-version": "^9",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
@@ -113,11 +113,13 @@
         }
       ]
     ],
-    "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.dev.json"
-      }
+    "transform": {
+      "^.+\\.[t]sx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.dev.json"
+        }
+      ]
     }
   },
   "types": "lib/index.d.ts",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -26,7 +26,6 @@
     "target": "ES2019"
   },
   "include": [
-    ".projenrc.js",
     "src/**/*.ts",
     "test/**/*.ts",
     ".projenrc.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4043,10 +4043,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-projen@~0.77.4:
-  version "0.77.4"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.77.4.tgz#d05393f49c326b00f42fc3814120fcd6f5fc0881"
-  integrity sha512-mErPkhiIweZ1GBfr8syClijfqNmPtAu1skOwsrm49lmyEIA8esqQCguzKV1/ytyv1N+4apfOUmkUW/+5dBTbPA==
+projen@~0.78.8:
+  version "0.78.13"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.78.13.tgz#5c6693ababa4f2e7d93759c722a35d41c9c2e691"
+  integrity sha512-ihL1lcfmi7M0EA7qgdXGja2SLLc6vtsQ1Wd2RqqxOuFnchw9/kZubdrxy38J8iI36AEwb0Qucb1uLTuwFhl7Qw==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
Projen 0.78.9 fixes the warning:

> (WARN) Define `ts-jest` config under `globals` is deprecated

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
