### PR TITLE
fix: do not require husky downstream

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -76,6 +76,10 @@
       "type": "build"
     },
     {
+      "name": "pinst",
+      "type": "build"
+    },
+    {
       "name": "projen",
       "version": "~0.78.8",
       "type": "build"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -272,13 +272,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@commitlint/config-conventional,@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,commitlint,eslint-import-resolver-typescript,eslint-plugin-header,eslint-plugin-import,eslint,husky,jest,jest-junit,jsii-diff,jsii-pacmak,standard-version,ts-jest,ts-node,typescript,aws-cdk-lib,constructs,cdk-nag"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@commitlint/config-conventional,@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,commitlint,eslint-import-resolver-typescript,eslint-plugin-header,eslint-plugin-import,eslint,husky,jest,jest-junit,jsii-diff,jsii-pacmak,pinst,standard-version,ts-jest,ts-node,typescript,aws-cdk-lib,constructs,cdk-nag"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @commitlint/config-conventional @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commitlint eslint-import-resolver-typescript eslint-plugin-header eslint-plugin-import eslint husky jest jest-junit jsii-diff jsii-pacmak standard-version ts-jest ts-node typescript aws-cdk-lib constructs cdk-nag"
+          "exec": "yarn upgrade @commitlint/config-conventional @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commitlint eslint-import-resolver-typescript eslint-plugin-header eslint-plugin-import eslint husky jest jest-junit jsii-diff jsii-pacmak pinst standard-version ts-jest ts-node typescript aws-cdk-lib constructs cdk-nag"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -50,7 +50,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'commitlint',
     'eslint-plugin-header',
     'husky',
-    // 'pinst',
+    'pinst',
   ],
   deps: ['cdk-nag'],
 
@@ -160,6 +160,8 @@ project.eslint?.addRules({
 const packageJson = project.tryFindObjectFile('package.json');
 packageJson?.patch(JsonPatch.add('/scripts/prepare', 'husky install')); // yarn 1
 packageJson?.patch(JsonPatch.add('/scripts/postinstall', 'husky install')); // yarn 2
+packageJson?.patch(JsonPatch.add('/scripts/prepack', 'pinst --disable'));
+packageJson?.patch(JsonPatch.add('/scripts/postpack', 'pinst --enable'));
 
 // Add generation of new available models for constructs
 project.addTask('generate-models-containers', {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "watch": "npx projen watch",
     "projen": "npx projen",
     "prepare": "husky install",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "prepack": "pinst --disable",
+    "postpack": "pinst --enable"
   },
   "author": {
     "name": "Amazon Web Services - Prototyping and Cloud Engineering",
@@ -57,6 +59,7 @@
     "jsii-diff": "^1.94.0",
     "jsii-pacmak": "^1.94.0",
     "jsii-rosetta": "~5.1.0",
+    "pinst": "^3.0.0",
     "projen": "~0.78.8",
     "standard-version": "^9",
     "ts-jest": "^29.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,6 +4307,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
 
+pinst@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pinst/-/pinst-3.0.0.tgz#80dec0a85f1f993c6084172020f3dbf512897eec"
+  integrity sha512-cengSmBxtCyaJqtRSvJorIIZXMXg+lJ3sIljGmtBGUVonMnMsVJbnzl6jGN1HkOWwxNuJynCJ2hXxxqCQrFDdw==
+
 pirates@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"


### PR DESCRIPTION
Because husky is only needed for local development remove the husky installation when packaging.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
