### PR TITLE
fix(documentation): use enum for responseGenerationMethod in example

### DIFF
--- a/src/patterns/gen-ai/aws-qa-appsync-opensearch/README.md
+++ b/src/patterns/gen-ai/aws-qa-appsync-opensearch/README.md
@@ -125,7 +125,7 @@ Mutation call to trigger the question:
 
 ```
 mutation MyMutation {
-  postQuestion(jobid: "123", jobstatus: "", max_docs: 10, question: "d2hhdCBpcyB0aGlzIGRvY3VtZW50IGFib3V0ID8=", streaming:true, verbose: true, filename: "document.txt", responseGenerationMethod: "RAG") {
+  postQuestion(jobid: "123", jobstatus: "", max_docs: 10, question: "d2hhdCBpcyB0aGlzIGRvY3VtZW50IGFib3V0ID8=", streaming:true, verbose: true, filename: "document.txt", responseGenerationMethod: RAG) {
     answer
     jobid
     jobstatus
@@ -148,7 +148,8 @@ Expected response:
       "max_docs": null,
       "question": null,
       "verbose": null,
-      "streaming": null
+      "streaming": null,
+      "responseGenerationMethod": null
     }
   }
 }


### PR DESCRIPTION
Updates the README for using the GraphQL enumeration instead of `String`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
