### PR TITLE
chore(bedrock): fix custom resource license header

### DIFF
--- a/lambda/bedrock-custom-resources/custom_resources/__init__.py
+++ b/lambda/bedrock-custom-resources/custom_resources/__init__.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 
 __version__ = "0.1.0"
 

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_agent.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_agent.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 import pickle  # nosec B403: pickle is used to create a hashable value. The value will never be deserialized.
 
 import uuid

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_agent_alias.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_agent_alias.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 
 """
 Input should be agentId, alias name, and hashes of any knowledge bases and action groups attached to identify changes.

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_agent_knowledgebase.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_agent_knowledgebase.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 import uuid
 
 import boto3

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_datasource.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_datasource.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 import uuid
 
 import boto3

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_knowledgebase.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_knowledgebase.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 import uuid
 
 import boto3

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_prepare_agent.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_prepare_agent.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 
 """
 Input should be agentId, alias name, and hashes of any knowledge bases and action groups attached to identify changes.

--- a/lambda/bedrock-custom-resources/custom_resources/cr_types.py
+++ b/lambda/bedrock-custom-resources/custom_resources/cr_types.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 
 from typing import TypeVar, TypedDict, Generic, Literal, NotRequired
 

--- a/lambda/bedrock-custom-resources/custom_resources/exceptions.py
+++ b/lambda/bedrock-custom-resources/custom_resources/exceptions.py
@@ -1,12 +1,15 @@
-# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# Licensed under the Amazon Software License (the "License"). You may not
-# use this file except in compliance with the License. A copy of the
-# License is located at:
-# http://aws.amazon.com/asl/
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
 import os
 
 import botocore.exceptions


### PR DESCRIPTION
This change corrects the license headers of the Bedrock custom resource code to Apache 2 instead of Amazon Software License.

Fixes #

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
