### PR TITLE
fix(lambda layer): fix wrong path preventing deployment

### DIFF
--- a/src/patterns/gen-ai/aws-langchain-common-layer/README.md
+++ b/src/patterns/gen-ai/aws-langchain-common-layer/README.md
@@ -73,7 +73,7 @@ const lambdaDepsLayer = new LangchainCommonDepsLayer(this, 'lambdagenaidepslayer
 
 const lambdaCommonLayer = new LangchainCommonLayer(this, 'lambdagenaicommonlayer', {
     compatibleRuntimes: [lambdaRuntime],
-    compatibleArchitectures: [lambdaArchitecture],,
+    compatibleArchitectures: [lambdaArchitecture],
 });
 
 //Then pass the layers above to your lambda function constructor

--- a/src/patterns/gen-ai/aws-langchain-common-layer/README.md
+++ b/src/patterns/gen-ai/aws-langchain-common-layer/README.md
@@ -72,8 +72,8 @@ const lambdaDepsLayer = new LangchainCommonDepsLayer(this, 'lambdagenaidepslayer
       });
 
 const lambdaCommonLayer = new LangchainCommonLayer(this, 'lambdagenaicommonlayer', {
-runtime: lambdaRuntime,
-architecture: lambdaArchitecture,
+    compatibleRuntimes: [lambdaRuntime],
+    compatibleArchitectures: [lambdaArchitecture],,
 });
 
 //Then pass the layers above to your lambda function constructor

--- a/src/patterns/gen-ai/aws-langchain-common-layer/index.ts
+++ b/src/patterns/gen-ai/aws-langchain-common-layer/index.ts
@@ -109,7 +109,7 @@ export class LangchainCommonLayer extends Construct {
     super(scope, id);
 
     const layer = new lambda.LayerVersion(this, 'Model Adapter Layer', {
-      code: lambda.Code.fromAsset(path.join(__dirname, '../../../../layers/model-adapter-layer')),
+      code: lambda.Code.fromAsset(path.join(__dirname, '../../../../layers/langchain-common-layer')),
       description: 'Utilities to instantiate a llm client adapter. Adapters include bedrock, sagemaker, and openai',
       ...props,
     });

--- a/test/patterns/gen-ai/aws-langchain-common-layer/aws-langchain-common-layer.test.ts
+++ b/test/patterns/gen-ai/aws-langchain-common-layer/aws-langchain-common-layer.test.ts
@@ -1,0 +1,89 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import {
+  LangchainCommonLayer,
+  LangchainCommonDepsLayer,
+} from '../../../../src/patterns/gen-ai/aws-langchain-common-layer';
+
+describe('LangchainCommonLayer construct', () => {
+
+  let LangchainCommonLayerTestTemplate: Template;
+  let LangchainCommonLayerTestConstruct: LangchainCommonLayer;
+
+  afterAll(() => {
+    console.log('Test completed');
+    console.log(LangchainCommonLayerTestTemplate.toJSON());
+  });
+
+  beforeAll(() => {
+
+    const LangchainCommonLayerTestStack = new cdk.Stack(undefined, undefined, {
+      env: { account: cdk.Aws.ACCOUNT_ID, region: 'us-east-1' },
+    });
+
+    // Lambda layer
+    const lambdaArchitecture = lambda.Architecture.ARM_64;
+    const lambdaRuntime = lambda.Runtime.PYTHON_3_10;
+
+    LangchainCommonLayerTestConstruct = new LangchainCommonLayer(LangchainCommonLayerTestStack, 'lambdagenaicommonlayer', {
+      compatibleRuntimes: [lambdaRuntime],
+      compatibleArchitectures: [lambdaArchitecture],
+    });
+    LangchainCommonLayerTestTemplate = Template.fromStack(LangchainCommonLayerTestStack);
+
+  });
+
+  test('LayerVersion count', () => {
+    LangchainCommonLayerTestTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 1);
+    expect(LangchainCommonLayerTestConstruct.layer).not.toBeNull;
+  });
+});
+
+describe('LangchainCommonDepsLayer construct', () => {
+
+  let LangchainCommonLayerDepsTestTemplate: Template;
+  let LangchainCommonLayerDepsTestConstruct: LangchainCommonDepsLayer;
+
+  afterAll(() => {
+    console.log('Test completed');
+    console.log(LangchainCommonLayerDepsTestTemplate.toJSON());
+  });
+
+  beforeAll(() => {
+
+    const LangchainCommonLayerDepsTestStack = new cdk.Stack(undefined, undefined, {
+      env: { account: cdk.Aws.ACCOUNT_ID, region: 'us-east-1' },
+    });
+
+    // Lambda layer
+    const lambdaArchitecture = lambda.Architecture.ARM_64;
+    const lambdaRuntime = lambda.Runtime.PYTHON_3_10;
+
+    LangchainCommonLayerDepsTestConstruct = new LangchainCommonDepsLayer(LangchainCommonLayerDepsTestStack, 'lambdagenaidepslayer', {
+      runtime: lambdaRuntime,
+      architecture: lambdaArchitecture,
+      autoUpgrade: true,
+    });
+    LangchainCommonLayerDepsTestTemplate = Template.fromStack(LangchainCommonLayerDepsTestStack);
+
+  });
+
+  test('LayerVersionDeps count', () => {
+    LangchainCommonLayerDepsTestTemplate.resourceCountIs('AWS::Lambda::LayerVersion', 1);
+    expect(LangchainCommonLayerDepsTestConstruct.layer).not.toBeNull;
+  });
+});
+


### PR DESCRIPTION
Fixes a bug in the Lambda Layer construct (regression) where the path to the asset is wrong, preventing correct deployment
- fix path
- fix documentation
- add tests to prevent regression in future releases

Tested manually in Typescript and Python to make sure it synths correctly

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
