### PR TITLE
feat(bedrock): method to add deps to PrepareAgent

### DIFF
--- a/apidocs/classes/bedrock.Agent.md
+++ b/apidocs/classes/bedrock.Agent.md
@@ -30,12 +30,15 @@ Deploy a Bedrock Agent.
 - [aliasId](bedrock.Agent.md#aliasid)
 - [aliasName](bedrock.Agent.md#aliasname)
 - [cdkTagManager](bedrock.Agent.md#cdktagmanager)
+- [changeIds](bedrock.Agent.md#changeids)
 - [name](bedrock.Agent.md#name)
 - [node](bedrock.Agent.md#node)
+- [prepareAgent](bedrock.Agent.md#prepareagent)
 - [role](bedrock.Agent.md#role)
 
 ### Methods
 
+- [\_addPrepareAgentDependency](bedrock.Agent.md#_addprepareagentdependency)
 - [addAlias](bedrock.Agent.md#addalias)
 - [toString](bedrock.Agent.md#tostring)
 - [isConstruct](bedrock.Agent.md#isconstruct)
@@ -116,6 +119,14 @@ cdk.ITaggableV2.cdkTagManager
 
 ___
 
+### changeIds
+
+• `Private` **changeIds**: `string`[] = `[]`
+
+A list of values to indicate if PrepareAgent or an Alias needs to be updated.
+
+___
+
 ### name
 
 • `Readonly` **name**: `string`
@@ -136,6 +147,16 @@ Construct.node
 
 ___
 
+### prepareAgent
+
+• `Private` **prepareAgent**: `CustomResource`
+
+The prepareAgent custom resource.
+
+Add other resources as dependencies to ensure Prepare Agent is called after they are updated.
+
+___
+
 ### role
 
 • `Readonly` **role**: `Role`
@@ -143,6 +164,25 @@ ___
 The IAM role for the agent.
 
 ## Methods
+
+### \_addPrepareAgentDependency
+
+▸ **_addPrepareAgentDependency**(`resource`, `changeId?`): `void`
+
+Register a dependency for prepareAgent.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `resource` | `IResource` | The resource that will be registered as a dependency. |
+| `changeId?` | `string` | The changeId of the resource that will be registered as a dependency. This is an internal core function and should not be called directly. |
+
+#### Returns
+
+`void`
+
+___
 
 ### addAlias
 

--- a/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
+++ b/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
@@ -26,6 +26,7 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "AgentAgentAliasprodAliasCRPolicyACECDEBD",
+        "AgentPrepareAgent9A21CF07",
         "BedrockCRProviderCRRole90406B17",
         "BedrockCRProviderCustomResourcesFunctionLogRetention32CED555",
         "BedrockCRProviderCustomResourcesFunction9A70E3A5",
@@ -67,6 +68,9 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
       "UpdateReplacePolicy": "Delete",
     },
     "AgentAgentAliasprodAliasCRPolicyACECDEBD": {
+      "DependsOn": [
+        "AgentPrepareAgent9A21CF07",
+      ],
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -409,6 +413,10 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
     },
     "AgentPrepareAgent9A21CF07": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AgentD78B2CA1",
+        "AgentKBAssocKBteststackKBF59CBB076A4D106D",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [


### PR DESCRIPTION
Fixes #229 

This change makes `changeIds` and `prepareAgent` private fields of agent and adds a public, but internal method named `_addPrepareAgentDependency` to resources created after the Agent, such as an upcoming Action Group, can be dependencies of the PrepareAgent custom resource.

Changes
* Moves the PrepareAgent custom resource to earlier in the file so the Agent and KB Associations can use  the method.
* Use the new method to make the agent and KB association custom resources dependencies of prepareAgent.
* Make prepareAgent a dependency of any aliases.
* Use cdk.Lazy to evaluate changeIds at the end of synth.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
