### PR TITLE
fix(bedrock): fix addAlias props

### DIFF
--- a/apidocs/classes/bedrock.Agent.md
+++ b/apidocs/classes/bedrock.Agent.md
@@ -194,7 +194,7 @@ Add an alias to the agent.
 
 | Name | Type |
 | :------ | :------ |
-| `props` | [`AgentAliasProps`](../interfaces/bedrock.AgentAliasProps.md) |
+| `props` | [`AddAgentAliasProps`](../interfaces/bedrock.AddAgentAliasProps.md) |
 
 #### Returns
 

--- a/apidocs/interfaces/bedrock.AddAgentAliasProps.md
+++ b/apidocs/interfaces/bedrock.AddAgentAliasProps.md
@@ -1,0 +1,36 @@
+[@cdklabs/generative-ai-cdk-constructs](../README.md) / [bedrock](../modules/bedrock.md) / AddAgentAliasProps
+
+# Interface: AddAgentAliasProps
+
+[bedrock](../modules/bedrock.md).AddAgentAliasProps
+
+Properties to add an Alias to an Agent
+
+## Table of contents
+
+### Properties
+
+- [agentVersion](bedrock.AddAgentAliasProps.md#agentversion)
+- [aliasName](bedrock.AddAgentAliasProps.md#aliasname)
+
+## Properties
+
+### agentVersion
+
+• `Optional` `Readonly` **agentVersion**: `string`
+
+The version of the agent to associate with the agent alias.
+
+**`Default`**
+
+```ts
+- Creates a new version of the agent.
+```
+
+___
+
+### aliasName
+
+• `Readonly` **aliasName**: `string`
+
+The name for the agent alias.

--- a/apidocs/modules/bedrock.md
+++ b/apidocs/modules/bedrock.md
@@ -22,6 +22,7 @@
 
 ### Interfaces
 
+- [AddAgentAliasProps](../interfaces/bedrock.AddAgentAliasProps.md)
 - [AgentAliasProps](../interfaces/bedrock.AgentAliasProps.md)
 - [AgentProps](../interfaces/bedrock.AgentProps.md)
 - [BedrockFoundationModelProps](../interfaces/bedrock.BedrockFoundationModelProps.md)

--- a/src/cdk-lib/bedrock/agent.ts
+++ b/src/cdk-lib/bedrock/agent.ts
@@ -17,7 +17,7 @@ import * as kms from 'aws-cdk-lib/aws-kms';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
-import { AgentAlias, AgentAliasProps } from './agent-alias';
+import { AgentAlias } from './agent-alias';
 import { BedrockCRProvider } from './custom-resource-provider';
 import { KnowledgeBase } from './knowledge-base';
 import { BedrockFoundationModel } from './models';
@@ -252,6 +252,22 @@ export interface AgentProps {
    * @default - No alias is created.
    */
   readonly aliasName?: string;
+}
+
+/**
+ * Properties to add an Alias to an Agent
+ */
+export interface AddAgentAliasProps {
+  /**
+   * The name for the agent alias.
+   */
+  readonly aliasName: string;
+  /**
+   * The version of the agent to associate with the agent alias.
+   *
+   * @default - Creates a new version of the agent.
+   */
+  readonly agentVersion?: string;
 }
 
 /**
@@ -510,7 +526,6 @@ export class Agent extends Construct implements cdk.ITaggableV2 {
 
     if (props.aliasName) {
       const alias = this.addAlias({
-        agentId: this.agentId,
         aliasName: props.aliasName,
       });
       this.aliasId = alias.aliasId;
@@ -522,7 +537,7 @@ export class Agent extends Construct implements cdk.ITaggableV2 {
   /**
    * Add an alias to the agent.
    */
-  public addAlias(props: Exclude<AgentAliasProps, 'agentId'>): AgentAlias {
+  public addAlias(props: AddAgentAliasProps): AgentAlias {
     const alias = new AgentAlias(this, `AgentAlias-${props.aliasName}`, {
       agentId: this.agentId,
       agentVersion: props.agentVersion,


### PR DESCRIPTION
Fixes #230 
This change builds on #231 .

Create `AddAgentAliasProps` as a partial copy of `AgentAliasProps` with `aliasName` becoming a required property.

If preferred, this could be implemented with https://github.com/mrgrain/jsii-struct-builder to work around JSII's lack of support for Omit types.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
