### PR TITLE
feat(bedrock): replace PrepareAgent with shouldPrepareAgent prop

### DIFF
--- a/apidocs/classes/bedrock.Agent.md
+++ b/apidocs/classes/bedrock.Agent.md
@@ -30,15 +30,15 @@ Deploy a Bedrock Agent.
 - [aliasId](bedrock.Agent.md#aliasid)
 - [aliasName](bedrock.Agent.md#aliasname)
 - [cdkTagManager](bedrock.Agent.md#cdktagmanager)
-- [changeIds](bedrock.Agent.md#changeids)
 - [name](bedrock.Agent.md#name)
 - [node](bedrock.Agent.md#node)
-- [prepareAgent](bedrock.Agent.md#prepareagent)
+- [resourceUpdates](bedrock.Agent.md#resourceupdates)
 - [role](bedrock.Agent.md#role)
+- [shouldPrepareAgent](bedrock.Agent.md#shouldprepareagent)
 
 ### Methods
 
-- [\_addPrepareAgentDependency](bedrock.Agent.md#_addprepareagentdependency)
+- [\_addAliasDependency](bedrock.Agent.md#_addaliasdependency)
 - [addActionGroup](bedrock.Agent.md#addactiongroup)
 - [addAlias](bedrock.Agent.md#addalias)
 - [toString](bedrock.Agent.md#tostring)
@@ -120,14 +120,6 @@ cdk.ITaggableV2.cdkTagManager
 
 ___
 
-### changeIds
-
-• `Private` **changeIds**: `string`[] = `[]`
-
-A list of values to indicate if PrepareAgent or an Alias needs to be updated.
-
-___
-
 ### name
 
 • `Readonly` **name**: `string`
@@ -148,13 +140,11 @@ Construct.node
 
 ___
 
-### prepareAgent
+### resourceUpdates
 
-• `Private` **prepareAgent**: `CustomResource`
+• `Private` **resourceUpdates**: `string`[] = `[]`
 
-The prepareAgent custom resource.
-
-Add other resources as dependencies to ensure Prepare Agent is called after they are updated.
+A list of values to indicate if PrepareAgent or an Alias needs to be updated.
 
 ___
 
@@ -164,20 +154,27 @@ ___
 
 The IAM role for the agent.
 
+___
+
+### shouldPrepareAgent
+
+• `Private` `Readonly` **shouldPrepareAgent**: `boolean`
+
+If prepare agent should be called on resource updates.
+
 ## Methods
 
-### \_addPrepareAgentDependency
+### \_addAliasDependency
 
-▸ **_addPrepareAgentDependency**(`resource`, `changeId?`): `void`
+▸ **_addAliasDependency**(`updatedAt`): `void`
 
-Register a dependency for prepareAgent.
+Register a dependency for aliases.
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `resource` | `IResource` | The resource that will be registered as a dependency. |
-| `changeId?` | `string` | The changeId of the resource that will be registered as a dependency. This is an internal core function and should not be called directly. |
+| `updatedAt` | `string` | The updatedAt of the resource that will be registered as a dependency. This is an internal core function and should not be called directly. |
 
 #### Returns
 

--- a/apidocs/interfaces/bedrock.AgentActionGroupProps.md
+++ b/apidocs/interfaces/bedrock.AgentActionGroupProps.md
@@ -15,6 +15,7 @@
 - [apiSchema](bedrock.AgentActionGroupProps.md#apischema)
 - [description](bedrock.AgentActionGroupProps.md#description)
 - [parentActionGroupSignature](bedrock.AgentActionGroupProps.md#parentactiongroupsignature)
+- [shouldPrepareAgent](bedrock.AgentActionGroupProps.md#shouldprepareagent)
 
 ## Properties
 
@@ -84,3 +85,17 @@ ___
 If you specify this value as AMAZON.UserInput, the agent will prompt additional information from the user when it
 doesn't have enough information to respond to an utterance. Leave this field blank if you don't want the agent to
 prompt additional information.
+
+___
+
+### shouldPrepareAgent
+
+• `Optional` `Readonly` **shouldPrepareAgent**: `boolean`
+
+Whether to prepare the agent for use.
+
+**`Default`**
+
+```ts
+- false
+```

--- a/apidocs/interfaces/bedrock.AgentAliasProps.md
+++ b/apidocs/interfaces/bedrock.AgentAliasProps.md
@@ -11,7 +11,7 @@
 - [agentId](bedrock.AgentAliasProps.md#agentid)
 - [agentVersion](bedrock.AgentAliasProps.md#agentversion)
 - [aliasName](bedrock.AgentAliasProps.md#aliasname)
-- [changeIds](bedrock.AgentAliasProps.md#changeids)
+- [resourceUpdates](bedrock.AgentAliasProps.md#resourceupdates)
 
 ## Properties
 
@@ -51,9 +51,8 @@ The name for the agent alias.
 
 ___
 
-### changeIds
+### resourceUpdates
 
-• `Optional` `Readonly` **changeIds**: `string`[]
+• `Optional` `Readonly` **resourceUpdates**: `string`[]
 
-The list of change ids to let CloudFormation determine when to update the alias.
-A changeId is a hash of the properties of an agent, an agent/knowledge base association, or an action group.
+The list of resource update timestamps to let CloudFormation determine when to update the alias.

--- a/apidocs/interfaces/bedrock.AgentProps.md
+++ b/apidocs/interfaces/bedrock.AgentProps.md
@@ -19,6 +19,7 @@ Properties for a Bedrock Agent.
 - [knowledgeBases](bedrock.AgentProps.md#knowledgebases)
 - [name](bedrock.AgentProps.md#name)
 - [promptOverrideConfiguration](bedrock.AgentProps.md#promptoverrideconfiguration)
+- [shouldPrepareAgent](bedrock.AgentProps.md#shouldprepareagent)
 
 ## Properties
 
@@ -132,4 +133,18 @@ Overrides for the agent.
 
 ```ts
 - No overrides are provided.
+```
+
+___
+
+### shouldPrepareAgent
+
+• `Optional` `Readonly` **shouldPrepareAgent**: `boolean`
+
+Whether to prepare the agent for use.
+
+**`Default`**
+
+```ts
+- false
 ```

--- a/lambda/bedrock-custom-resources/custom_resources/__init__.py
+++ b/lambda/bedrock-custom-resources/custom_resources/__init__.py
@@ -26,7 +26,6 @@ from .bedrock_agent_knowledgebase import (
     on_event as on_event_bedrock_agent_knowledgebase,
 )
 from .bedrock_agent_action_group import on_event as on_event_bedrock_agent_action_group
-from .bedrock_prepare_agent import on_event as on_event_bedrock_prepare_agent
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 
@@ -50,8 +49,6 @@ def on_event(event: CustomResourceRequest, context):
         return on_event_bedrock_knowledgebase(event, context)
     if resource_type == "Custom::Bedrock-DataSource":
         return on_event_bedrock_datasource(event, context)
-    if resource_type == "Custom::Bedrock-PrepareAgent":
-        return on_event_bedrock_prepare_agent(event, context)
     if resource_type == "Custom::NoOp":
         logger.info("NoOp resource type")
         # Return a response with a physical resource ID that is not empty.

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_datasource.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_datasource.py
@@ -122,6 +122,7 @@ def on_event(event: CustomResourceRequest[Dict], context):
     retry=retry_if_exception_type(AWSRetryableError),
     stop=stop_after_attempt(10),
     wait=wait_exponential_jitter(1, 15),
+    reraise=True,
 )
 def on_create(
     event: CustomResourceRequest[DataSourceRequest], client_token=None
@@ -149,6 +150,7 @@ def on_create(
     retry=retry_if_exception_type(AWSRetryableError),
     stop=stop_after_attempt(3),
     wait=wait_exponential_jitter(1, 3),
+    reraise=True,
 )
 def on_update(
     event: CustomResourceRequest[DataSourceRequest],
@@ -175,6 +177,7 @@ def on_update(
     retry=retry_if_exception_type(AWSRetryableError),
     stop=stop_after_attempt(3),
     wait=wait_exponential_jitter(1, 3),
+    reraise=True,
 )
 def on_delete(event: CustomResourceRequest[Dict]) -> CustomResourceResponse:
     bedrock_agent = session.client("bedrock-agent")

--- a/lambda/bedrock-custom-resources/custom_resources/bedrock_knowledgebase.py
+++ b/lambda/bedrock-custom-resources/custom_resources/bedrock_knowledgebase.py
@@ -61,6 +61,7 @@ def on_event(event: CustomResourceRequest[Dict], context):
     retry=retry_if_exception_type(AWSRetryableError),
     stop=stop_after_attempt(7),
     wait=wait_exponential_jitter(1, 15),
+    reraise=True,
 )
 def on_create(
     event: CustomResourceRequest[Dict], bedrock_agent, client_token=None
@@ -86,6 +87,7 @@ def on_create(
     retry=retry_if_exception_type(AWSRetryableError),
     stop=stop_after_attempt(7),
     wait=wait_exponential_jitter(1, 15),
+    reraise=True,
 )
 def on_update(
     event: CustomResourceRequest[Dict], bedrock_agent
@@ -112,6 +114,7 @@ def on_update(
     retry=retry_if_exception_type(AWSRetryableError),
     stop=stop_after_attempt(3),
     wait=wait_exponential_jitter(1, 3),
+    reraise=True,
 )
 def on_delete(
     event: CustomResourceRequest[Dict], bedrock_agent

--- a/src/cdk-lib/bedrock/README.md
+++ b/src/cdk-lib/bedrock/README.md
@@ -94,7 +94,9 @@ agent.addActionGroup({
 ```
 
 ### Prepare the Agent
-The custom resources return hashes of their properties in their `changeId` attribute. The Agent resource uses them to make sure CloudFormation will prepare the agent on any change.
+The `Agent` and `AgentActionGroup` constructs take an optional parameter `shouldPrepareAgent` to indicate that the Agent should be prepared after any updates to an agent, Knowledge Base association, or action group. This may increase the time to create and update those resources.
+
+Creating an agent alias will also prepare the agent, so if you create an alias with `addAlias` or by providing an `aliasName` when creating the agent then you should not set `shouldPrepareAgent` to ***true*** on other resources.
 
 #### Prompt Overrides
 Bedrock Agents allows you to customize the prompts and LLM configuration for its different steps. You can disable steps or create a new prompt template. Prompt templates can be inserted from plain text files.

--- a/src/cdk-lib/bedrock/agent-action-group.ts
+++ b/src/cdk-lib/bedrock/agent-action-group.ts
@@ -58,7 +58,12 @@ export interface AgentActionGroupProps {
    * prompt additional information.
    */
   readonly parentActionGroupSignature?: 'AMAZON.UserInput';
-
+  /**
+   * Whether to prepare the agent for use.
+   *
+   * @default - false
+   */
+  readonly shouldPrepareAgent?: boolean;
 }
 
 interface ActionGroupExecutor {
@@ -106,6 +111,7 @@ export class AgentActionGroup extends Construct {
         apiSchema,
         description: props.description,
         parentActionGroupSignature: props.parentActionGroupSignature,
+        shouldPrepareAgent: props.shouldPrepareAgent,
       },
     });
     this.actionGroupId = agentActionGroup.getAttString('actionGroupId');
@@ -143,7 +149,7 @@ export class AgentActionGroup extends Construct {
     );
 
     agentActionGroup.node.addDependency(actionGroupCRPolicy);
-    props.agent._addPrepareAgentDependency(agentActionGroup, agentActionGroup.getAttString('updatedAt'));
+    props.agent._addAliasDependency(agentActionGroup.getAttString('updatedAt'));
   }
 }
 

--- a/src/cdk-lib/bedrock/agent-alias.ts
+++ b/src/cdk-lib/bedrock/agent-alias.ts
@@ -30,10 +30,9 @@ export interface AgentAliasProps {
    */
   readonly aliasName?: string;
   /**
-   * The list of change ids to let CloudFormation determine when to update the alias.
-   * A changeId is a hash of the properties of an agent, an agent/knowledge base association, or an action group.
+   * The list of resource update timestamps to let CloudFormation determine when to update the alias.
    */
-  readonly changeIds?: string[];
+  readonly resourceUpdates?: string[];
   /**
    * The version of the agent to associate with the agent alias.
    *
@@ -74,7 +73,7 @@ export class AgentAlias extends Construct implements cdk.ITaggableV2 {
         properties: {
           agentId: props.agentId,
           aliasName: props.aliasName ?? 'latest',
-          changeIds: props.changeIds,
+          resourceUpdates: props.resourceUpdates,
           agentVersion: props.agentVersion,
           tags: this.cdkTagManager.renderedTags,
         },

--- a/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
+++ b/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
@@ -46,6 +46,7 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
           "payload": "mock schema",
         },
         "description": "Use these functions to get information about the books in the Project Gutenburg library.",
+        "shouldPrepareAgent": false,
       },
       "Type": "Custom::Bedrock-AgentActionGroup",
       "UpdateReplacePolicy": "Delete",
@@ -100,7 +101,6 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "AgentAgentAliasprodAliasCRPolicyACECDEBD",
-        "AgentPrepareAgent9A21CF07",
         "BedrockCRProviderCRRole90406B17",
         "BedrockCRProviderCustomResourcesFunctionLogRetention32CED555",
         "BedrockCRProviderCustomResourcesFunction9A70E3A5",
@@ -123,17 +123,17 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
           ],
         },
         "aliasName": "prod",
-        "changeIds": [
+        "resourceUpdates": [
           {
             "Fn::GetAtt": [
               "AgentD78B2CA1",
-              "changeId",
+              "updatedAt",
             ],
           },
           {
             "Fn::GetAtt": [
               "AgentKBAssocKBteststackKBF59CBB076A4D106D",
-              "changeId",
+              "updatedAt",
             ],
           },
           {
@@ -148,9 +148,6 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
       "UpdateReplacePolicy": "Delete",
     },
     "AgentAgentAliasprodAliasCRPolicyACECDEBD": {
-      "DependsOn": [
-        "AgentPrepareAgent9A21CF07",
-      ],
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -250,6 +247,7 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
                 "bedrock:DeleteAgent",
                 "bedrock:UpdateAgent",
                 "bedrock:TagResource",
+                "bedrock:GetAgent",
                 "bedrock:PrepareAgent",
               ],
               "Effect": "Allow",
@@ -391,6 +389,7 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
             },
           ],
         },
+        "shouldPrepareAgent": false,
       },
       "Type": "Custom::Bedrock-Agent",
       "UpdateReplacePolicy": "Delete",
@@ -487,52 +486,9 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
             "knowledgeBaseId",
           ],
         },
+        "shouldPrepareAgent": false,
       },
       "Type": "Custom::Bedrock-AgentKnowledgeBase",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "AgentPrepareAgent9A21CF07": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "AgentD78B2CA1",
-        "AgentAgentActionGrouptestactiongroupActionGroupD0F433CF",
-        "AgentKBAssocKBteststackKBF59CBB076A4D106D",
-      ],
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "BedrockCRProviderframeworkonEvent412F4EF1",
-            "Arn",
-          ],
-        },
-        "agentId": {
-          "Fn::GetAtt": [
-            "AgentD78B2CA1",
-            "agentId",
-          ],
-        },
-        "changeIds": [
-          {
-            "Fn::GetAtt": [
-              "AgentD78B2CA1",
-              "changeId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "AgentKBAssocKBteststackKBF59CBB076A4D106D",
-              "changeId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "AgentAgentActionGrouptestactiongroupActionGroupD0F433CF",
-              "updatedAt",
-            ],
-          },
-        ],
-      },
-      "Type": "Custom::Bedrock-PrepareAgent",
       "UpdateReplacePolicy": "Delete",
     },
     "AgentRole9D587F56": {


### PR DESCRIPTION
Per discussions with @massi-ang and the CloudFormation team, there shouldn't be a resource to call PrepareAgent as it doesn't create anything. This change replaces the custom resource with an optional property called `shouldPrepareAgent` that calls and waits for the agent to be prepared after creating or updating the agent, action group, or knowledge base association custom resources.

Alias creation and updates still prepare the agent first. Developers can choose whether to use `shouldPrepareAgent` or create an alias that tracks the latest changes to ensure that their agent is prepared. This change makes the alias custom resource use the same function to prepare the agent and wait as the others.

This change replaces the complicated `changeId` hashes with the `updatedAt` timestamps returned by the SDK in order to determine when to update the alias.

Custom Resource exceptions are reraised by the retry mechanism.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
