### PR TITLE
feat(ingestimagedocs): ingest jpg,png files and create embeddings wit…

### DIFF
--- a/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/helpers/image_loader.py
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/helpers/image_loader.py
@@ -1,0 +1,120 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+import base64
+import json
+import os
+from typing import List
+from aiohttp import ClientError
+
+from aws_lambda_powertools import Logger, Tracer
+#from langchain_community.document_loaders.image import UnstructuredImageLoader
+from langchain.docstore.document import Document
+
+import boto3
+
+s3 = boto3.client('s3')
+
+logger = Logger(service="INGESTION_FILE_TRANSFORMER")
+tracer = Tracer(service="INGESTION_FILE_TRANSFORMER")
+
+@tracer.capture_method
+class image_loader():
+    """Loading logic for pdf documents from s3 ."""
+
+    def __init__(self, bucket: str, image_file: str,image_detail_file: str):
+        """Initialize with bucket and key name."""
+        self.bucket = bucket
+        self.image_file = image_file
+        self.image_detail_file = image_detail_file
+       
+
+    
+    @tracer.capture_method
+    def load(self):
+        """Load documents."""
+        try:
+            local_file_path = self.download_file(self.image_file)
+            print(f"file downloaded :: {local_file_path}")
+            
+            with open(f"{local_file_path}", "rb") as image_file:
+                input_image = base64.b64encode(image_file.read()).decode("utf8")
+            
+            s3 = boto3.resource('s3')
+            obj = s3.Object(self.bucket, self.image_detail_file)
+            raw_text = obj.get()['Body'].read().decode('utf-8') 
+
+            metadata = {"source": self.image_file}
+
+            docs = json.dumps({
+                    "inputImage": input_image,
+                    #"inputText": raw_text,
+                               })
+            #print(f'docs for titan embeddings {docs}')
+            return [Document(page_content=docs, metadata=metadata)]
+            
+        except Exception as exception:
+            logger.exception(f"Reason: {exception}")
+            return ""
+        
+    @tracer.capture_method
+    def get_presigned_url(self) -> str:
+        try:
+             url = s3.generate_presigned_url(
+                ClientMethod='get_object', 
+                Params={'Bucket': self.bucket, 'Key': self.image_file},
+                ExpiresIn=900
+                )
+             print(f"presigned url generated for {self.image_file} from {self.bucket}")
+             return url
+        except Exception as exception:
+            logger.exception(f"Reason: {exception}")
+            return ""
+        
+    @tracer.capture_method
+    def download_file(self,key )-> str:
+        try: 
+            file_path = "/tmp/" + os.path.basename(key)
+            s3.download_file(self.bucket, key,file_path)
+            print(f"file downloaded {file_path}")
+            return file_path
+        except ClientError as client_err:
+            print(f"Couldn\'t download file {client_err.response['Error']['Message']}")
+        
+        except Exception as exp:
+            print(f"Couldn\'t download file : {exp}")
+
+    @tracer.capture_method
+    def prepare_document_for_direct_load(self)->any:
+            local_file_path = self.download_file(self.image_file)
+            print(f" prepare os_document")
+            
+            with open(f"{local_file_path}", "rb") as image_file:
+                input_image = base64.b64encode(image_file.read()).decode("utf8")
+            
+            s3 = boto3.resource('s3')
+            obj = s3.Object(self.bucket, self.image_detail_file)
+            raw_text = obj.get()['Body'].read().decode('utf-8') 
+
+            metadata = {"source": self.image_file}
+
+            docs = json.dumps({
+                    "inputImage": input_image,
+                    #"inputText": raw_text,
+                               })
+            
+            os_document = {
+                "image_words": raw_text,
+                "image_vector": input_image,
+            }
+            print (f'os_document prepared ')
+            return os_document

--- a/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/helpers/opensearch_helper.py
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/helpers/opensearch_helper.py
@@ -37,12 +37,12 @@ def check_if_index_exists(index_name: str, region: str, host: str, http_auth: Tu
     print(f"index_name={index_name}, exists={exists}")
     return exists
 
-def process_shard(shard, os_index_name, os_domain_ep, os_http_auth) -> int: 
+def process_shard(shard, os_index_name, os_domain_ep, os_http_auth,model_id) -> int: 
     print(f'Starting process_shard of {len(shard)} chunks.')
     bedrock_client = boto3.client('bedrock-runtime')
     embeddings = BedrockEmbeddings(
         client=bedrock_client, 
-        model_id="amazon.titan-embed-text-v1")
+        model_id=model_id)
     opensearch_url = os_domain_ep if os_domain_ep.startswith("https://") else f"https://{os_domain_ep}"
     docsearch = OpenSearchVectorSearch(index_name=os_index_name,
                                        embedding_function=embeddings,
@@ -54,3 +54,52 @@ def process_shard(shard, os_index_name, os_domain_ep, os_http_auth) -> int:
     docsearch.add_documents(documents=shard)
     print(f'Shard completed')
     return 0
+
+# TODO - Use this to create index in OS if langchain community process_shard throws issues with image.
+# otherwise remove this function.
+def create_index_for_image(index_name: str, region: str, host: str, http_auth: Tuple[str, str],document):
+    # Create Index, generates a warning if index already exists
+    print(f' create index on os without langchain utility ')
+    aos_client = OpenSearch(
+        hosts = [{'host': host.replace("https://", ""), 'port': 443}],
+        http_auth = http_auth,
+        use_ssl = True,
+        verify_certs = True,
+        connection_class = RequestsHttpConnection
+    )
+
+     # Create an index
+    if not aos_client.indices.exists(index=index_name):
+        print(f' conection made , creating index....')
+        aos_client.indices.create(
+            index=index_name,
+            body={
+                "settings":{
+                "index.knn": True,
+                "index.knn.space_type": "cosinesimil",
+                "analysis": {
+                    "analyzer": {"default": {"type": "standard", "stopwords": "_english_"}}
+                },
+            },
+            "mappings":{
+                "properties": {
+                    "image_vector": {
+                        "type": "knn_vector",
+                        "dimension": len(document["image_vector"]),
+                        "store": True,
+                    },
+                    "image_path": {"type": "text", "store": True},
+                    "image_words": {"type": "text", "store": True},
+                    "celebrities": {"type": "text", "store": True},
+                }
+                }
+                }
+
+             )
+    else:
+         print(f' index already exist , document loading ....')
+    # Create documents
+    result=  aos_client.index(
+        index=index_name, body=document
+    )
+    print(' embeddings uploaded in os {result}')

--- a/lambda/aws-rag-appsync-stepfn-opensearch/input_validation/src/lambda.py
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/input_validation/src/lambda.py
@@ -26,7 +26,7 @@ def process_files(input_files):
     for i in range(len(input_files)):
         filename = input_files[i]['name']
         status = "Unsupported"
-        if filename.lower().endswith(('.pdf')):
+        if isvalid_file_format(filename):
             status = "Supported"
             metrics.add_metric(name="SupportedFile", unit=MetricUnit.Count, value=1)
         else:
@@ -49,7 +49,7 @@ def process_files(input_files):
     return response
 
 @tracer.capture_method
-def append_job_info(response, job_id, ignore_existing):
+def append_job_info(response, job_id, ignore_existing,modelid):
     """
     Append job ID and ignore_existing flag to 
     each file in the provided response
@@ -57,7 +57,19 @@ def append_job_info(response, job_id, ignore_existing):
     for file in response['files']:
         file['jobid'] = job_id
         file['ignore_existing'] = ignore_existing
+        file['modelid']=modelid
     return response
+
+@tracer.capture_method
+def isvalid_file_format(file_name: str) -> bool:
+    file_format = ['.pdf','.txt','.jpg','.jpeg','.png','.csv','.docx','.ppt','.html','.jpeg']
+    if file_name.endswith(tuple(file_format)):
+        print(f'valid file format :: {file_format}')
+        return True
+    else:
+        print(f'Invalid file format :: {file_format}')
+        return False
+
 
 @logger.inject_lambda_context(log_event=True)
 @tracer.capture_lambda_handler
@@ -74,12 +86,16 @@ def handler(event,  context: LambdaContext) -> dict:
     tracer.put_annotation(key="correlationId", value=job_id)
 
     input_files = ingestion_input['files']
+    embeddings_model = ingestion_input['embeddings_model']
+    print(f'embeddings_model :: {embeddings_model}')
+    modelid = embeddings_model['modelId']
+    print(f'modelid :: {modelid}')
     
     response = process_files(input_files)
 
     updateIngestionJobStatus({'jobid': job_id, 'files': response['files']})
 
-    response_transformed = append_job_info(response, job_id, ignore_existing)
+    response_transformed = append_job_info(response, job_id, ignore_existing,modelid)
     
     logger.info({"response": response_transformed})
     return response_transformed

--- a/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/helpers/image_transformer.py
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/helpers/image_transformer.py
@@ -1,0 +1,138 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+from typing import List
+import boto3
+import os
+from aws_lambda_powertools import Logger, Tracer
+from PIL import Image
+
+
+
+logger = Logger(service="INGESTION_FILE_TRANSFORMER")
+tracer = Tracer(service="INGESTION_FILE_TRANSFORMER")
+
+
+class image_transformer():
+    """Transforming logic for uploaded image from s3 ."""
+
+    def __init__(self, image, image_name, rekognition_client):
+        """Initialize with bucket , key and rekognition_client."""
+        self.image = image
+        self.image_name = image_name
+        self.rekognition_client = rekognition_client
+
+    @classmethod
+    def from_file(cls, image_file_name, rekognition_client, image_name=None):
+        """
+        Creates a RekognitionImage object from a local file.
+
+        :param image_file_name: The file name of the image. The file is opened and its
+                                bytes are read.
+        :param rekognition_client: A Boto3 Rekognition client.
+        :param image_name: The name of the image. If this is not specified, the
+                           file name is used as the image name.
+        :return: The RekognitionImage object, initialized with image bytes from the
+                 file.
+        """
+        with open(image_file_name, "rb") as img_file:
+            image = {"Bytes": img_file.read()}
+        name = image_file_name if image_name is None else image_name
+        return cls(image, name, rekognition_client)
+    
+    @tracer.capture_method
+    def load(self) -> str:
+        """Load documents."""
+        try:
+            # TODO add transformation logic
+            print(f"No transformation logic implemented, copy the file {self.key} to processed bucket")        
+        except Exception as exception:
+            logger.exception(f"Reason: {exception}")
+            return ""
+        
+
+    @tracer.capture_method
+    def check_moderation(self)-> str:
+        isToxicImage = False
+        rekognition_response = self.rekognition_client.detect_moderation_labels(
+                         Image=self.image)
+        print('lables detected!')
+        print(rekognition_response)
+        for label in rekognition_response['ModerationLabels']:
+                if(label['Confidence'] > 0.60):
+                        isToxicImage=True
+                        print(f'Image failed moderation check, exit image uploading')
+                        break   
+
+        return isToxicImage
+    
+    @tracer.capture_method
+    def detect_image_lables(self)-> str:
+        try:
+            labels=[]
+            response = self.rekognition_client.detect_labels(Image=self.image,MaxLabels=20 )       
+            for label in response['Labels']:
+                print(label)
+                if(label['Confidence'] > 0.80):
+                    labels.append(label['Name'])
+        except Exception as exp:
+            print(f"Couldn't analyze image: {exp}")
+        return labels
+
+
+    @tracer.capture_method
+    def recognize_celebrities(self)-> str:
+        try:
+            celebrities=[]
+            response = self.rekognition_client.recognize_celebrities(Image=self.image)
+            print(f'Detected faces for :: { response}')
+            for celebrity in response['CelebrityFaces']:
+                celebrities.append(celebrity['Name'])
+            # for face in response['UnrecognizedFaces']:
+            #     celebrities.append(face['UnrecognizedFaces'])
+            
+        except Exception as exp:
+            print(f"Couldn't analyze image: {exp}")
+            
+        return celebrities
+
+    @tracer.capture_method
+    def image_resize(self)-> str:
+        width = 2048
+        height = 2048 
+
+        print(f'self.image {self.image} ')
+        
+        Image.MAX_IMAGE_PIXELS = 100000000
+        fileshort = os.path.basename(self.image_name)
+
+        print(f'fileshort {fileshort} ')
+        file_tmp = "/tmp/" + fileshort
+        
+        with Image.open(file_tmp) as image:
+                image.verify()
+        with Image.open(file_tmp) as image:  
+        
+            if image.format in ["JPEG","JPG", "PNG"]:
+                file_type = image.format.lower()
+                path = image.filename.rsplit(".", 1)[0]
+
+                image.thumbnail((width, height))
+                image.save(f"{path}-resized.{file_type}")
+
+                fileshort = os.path.basename(path)
+                print(f"file resized ")
+                
+            else:
+                raise Exception("Unsupported image format")
+            
+        return f"{fileshort}-resized.{file_type}"

--- a/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/helpers/utils.py
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/helpers/utils.py
@@ -1,0 +1,76 @@
+
+import boto3
+import os
+import json
+from aws_lambda_powertools import Logger, Tracer, Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+from helpers.image_transformer import image_transformer
+from botocore.exceptions import ClientError
+
+
+
+rekognition=boto3.client('rekognition')
+s3 = boto3.client('s3')
+
+logger = Logger(service="INGESTION_FILE_TRANSFORMER")
+tracer = Tracer(service="INGESTION_FILE_TRANSFORMER")
+metrics = Metrics(namespace="ingestion_pipeline", service="INGESTION_FILE_TRANSFORMER")
+
+@tracer.capture_method
+def isvalid_file_format(file_name: str) -> bool:
+    file_format = ['.pdf','.txt','.jpg','.png','.csv','.docx','.ppt','.html','.jpeg']
+    if file_name.endswith(tuple(file_format)):
+        return True
+    else:
+        print(f'Invalid file format :: {file_format}')
+        return False
+    
+
+
+@tracer.capture_method
+def transform_image_document(input_bucket: str,file_name: str,output_bucket: str):  
+        
+        image = download_file(input_bucket,file_name)        
+        imt= image_transformer.from_file(image, rekognition)
+        if(imt.check_moderation()):
+                return 'Image not supported'
+        else:
+                result_lables = imt.detect_image_lables()
+                result_celeb =  imt.recognize_celebrities()
+                image_details = {
+                        "image_lables":result_lables,
+                        "image_celeb":result_celeb
+                        }               
+                name, extension = os.path.splitext(file_name)
+                with open ('/tmp/'+name+'.txt','w') as f:
+                        f.write(json.dumps(image_details))
+                s3.upload_file('/tmp/'+name+'.txt',output_bucket,name+".txt")
+                downloaded_file = download_file(input_bucket,file_name)
+                print(f'downloaded_file:: {downloaded_file}')
+                
+                resize_image = imt.image_resize()
+                upload_file(output_bucket,resize_image)
+                #upload_file(output_bucket,file_name)
+                return 'File transformed'
+               
+def download_file(bucket, object )-> str:
+        try: 
+            file_path = "/tmp/" + os.path.basename(object)
+            s3.download_file(bucket, object,file_path)
+            return file_path
+        except ClientError as client_err:
+            print(f"Couldn\'t download file {client_err.response['Error']['Message']}")
+        
+        except Exception as exp:
+            print(f"Couldn\'t download file : {exp}")
+
+def upload_file(bucket, object )-> str:
+        try: 
+            file_path = "/tmp/" + os.path.basename(object)
+            s3.upload_file(file_path, bucket,object)
+            return file_path
+        except ClientError as client_err:
+            print(f"Couldn\'t download file {client_err.response['Error']['Message']}")
+        
+        except Exception as exp:
+            print(f"Couldn\'t download file : {exp}")

--- a/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/requirements.txt
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/requirements.txt
@@ -6,3 +6,5 @@ boto3
 requests
 langchain==0.1.4
 pypdf2
+Pillow
+langchain-community==0.0.16

--- a/resources/gen-ai/aws-rag-appsync-stepfn-opensearch/schema.graphql
+++ b/resources/gen-ai/aws-rag-appsync-stepfn-opensearch/schema.graphql
@@ -1,11 +1,20 @@
 type FileStatus @aws_iam @aws_cognito_user_pools {
 	name: String
 	status: String
+	imageurl: String
+}
+
+input ModelConfiguration {
+	provider: String
+	modelId: String
+	streaming: Boolean
+	model_kwargs: AWSJSON
 }
 
 input FileStatusInput {
 	name: String
 	status: String
+	imageurl: String
 }
 
 type IngestionDocs @aws_iam @aws_cognito_user_pools {
@@ -15,6 +24,7 @@ type IngestionDocs @aws_iam @aws_cognito_user_pools {
 
 input IngestionDocsInput {
 	ingestionjobid: ID
+	embeddings_model: ModelConfiguration
 	files: [FileStatusInput]
 	ignore_existing: Boolean
 }

--- a/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
+++ b/src/patterns/gen-ai/aws-rag-appsync-stepfn-opensearch/index.ts
@@ -502,6 +502,26 @@ export class RagAppsyncStepfnOpensearch extends Construct {
       ],
     }));
 
+    // Minimum permissions for a Lambda function to execute while accessing a resource within a VPC
+    s3_transformer_job_function_role.addToPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'rekognition:CompareFaces',
+        'rekognition:DetectFaces',
+        'rekognition:DetectLabels',
+        'rekognition:ListFaces',
+        'rekognition:SearchFaces',
+        'rekognition:SearchFacesByImage',
+        'rekognition:DetectText',
+        'rekognition:GetCelebrityInfo',
+        'rekognition:RecognizeCelebrities',
+        'rekognition:DetectModerationLabels',
+      ],
+      //TODO: change the resource to specific arn
+      resources: ['*'],
+    }));
+
+
     s3_transformer_job_function_role.addToPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,


### PR DESCRIPTION
Fixes #

1. Support for **ingesting .jpg,.jpeg,.png files**.
2. Added image transformer to detect lables, image moderation and image resize.
3. Added image loader to load image in Document format 
4. Updated schema to accept **model_id, and parameters from user.** 
5. Updated lambda to create embeddings using **amazon.titan-embed-image-v1** modal 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
