### PR TITLE
chore(sg): remove default value for volumesize property

### DIFF
--- a/apidocs/classes/CustomSageMakerEndpoint.md
+++ b/apidocs/classes/CustomSageMakerEndpoint.md
@@ -34,7 +34,6 @@
 - [node](CustomSageMakerEndpoint.md#node)
 - [role](CustomSageMakerEndpoint.md#role)
 - [startupHealthCheckTimeoutInSeconds](CustomSageMakerEndpoint.md#startuphealthchecktimeoutinseconds)
-- [volumeSizeInGb](CustomSageMakerEndpoint.md#volumesizeingb)
 
 ### Methods
 
@@ -163,12 +162,6 @@ ___
 ### startupHealthCheckTimeoutInSeconds
 
 • `Private` `Readonly` **startupHealthCheckTimeoutInSeconds**: `number`
-
-___
-
-### volumeSizeInGb
-
-• `Optional` `Readonly` **volumeSizeInGb**: `number`
 
 ## Methods
 

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/README_custom_sagemaker_endpoint.md
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/README_custom_sagemaker_endpoint.md
@@ -145,7 +145,6 @@ Parameters
 ## Default properties
 
 - iam.Role: if not provided, an iam.Role will be created by the construct with a managed policy providing AmazonSageMakerFullAccess permissions.
-- volumeSizeInGb: 512Gb if not provided
 - startupHealthCheckTimeoutInSeconds: 600 if not provided
 - modelDataDownloadTimeoutInSeconds: 600 if not provided
 - instanceCount: 1 if not provided

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/custom-sagemaker-endpoint.ts
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/custom-sagemaker-endpoint.ts
@@ -28,7 +28,7 @@ export interface CustomSageMakerEndpointProps {
   readonly environment?: { [key: string]: string };
   readonly startupHealthCheckTimeoutInSeconds?: number;
   readonly modelDataDownloadTimeoutInSeconds?: number;
-  readonly volumeSizeInGb?: number;
+  readonly volumeSizeInGb?: number | undefined;
   readonly vpcConfig?: sagemaker.CfnModel.VpcConfigProperty | undefined;
   readonly modelDataUrl: string;
 }
@@ -45,7 +45,6 @@ export class CustomSageMakerEndpoint extends SageMakerEndpointBase implements ia
   public readonly role: iam.Role;
   public readonly modelDataUrl: string;
   public readonly modelId: string;
-  public readonly volumeSizeInGb?: number;
   public readonly modelDataDownloadTimeoutInSeconds: number;
   private readonly startupHealthCheckTimeoutInSeconds: number;
   private readonly environment?: { [key: string]: string };
@@ -61,7 +60,6 @@ export class CustomSageMakerEndpoint extends SageMakerEndpointBase implements ia
     this.modelDataUrl = props.modelDataUrl;
     this.startupHealthCheckTimeoutInSeconds = props.startupHealthCheckTimeoutInSeconds ?? 600;
     this.environment = props.environment;
-    this.volumeSizeInGb = props.volumeSizeInGb ?? 512;
     this.modelDataDownloadTimeoutInSeconds = props.modelDataDownloadTimeoutInSeconds ?? 600;
 
     const image = props.container.bind(this, this.grantPrincipal).imageName;
@@ -109,7 +107,7 @@ export class CustomSageMakerEndpoint extends SageMakerEndpointBase implements ia
           initialVariantWeight: 1,
           initialInstanceCount: this.instanceCount,
           variantName: 'AllTraffic',
-          volumeSizeInGb: this.volumeSizeInGb,
+          volumeSizeInGb: props.volumeSizeInGb,
           modelName: model.getAtt('ModelName').toString(),
           containerStartupHealthCheckTimeoutInSeconds: this.startupHealthCheckTimeoutInSeconds,
           modelDataDownloadTimeoutInSeconds: this.modelDataDownloadTimeoutInSeconds,


### PR DESCRIPTION
Fixes #

Currently, we force a default value for the volumesizeingb property in the custom sg endpoint. However, for some instance types, this is not supported and fails at deploy time. We now use the value passed through props only if provided

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
