### PR TITLE
chore(construct): SageMaker JumpStart construct endpoint name update

### DIFF
--- a/apidocs/interfaces/JumpStartSageMakerEndpointProps.md
+++ b/apidocs/interfaces/JumpStartSageMakerEndpointProps.md
@@ -26,7 +26,7 @@ ___
 
 ### endpointName
 
-• `Optional` `Readonly` **endpointName**: `string`
+• `Readonly` **endpointName**: `string`
 
 ___
 

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/README_jumpstart.md
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/README_jumpstart.md
@@ -98,7 +98,7 @@ Parameters
 | **Name**     | **Type**        | **Required** |**Description** |
 |:-------------|:----------------|-----------------|-----------------|
 | model | JumpStartModel | ![Required](https://img.shields.io/badge/required-ff0000) | The model to deploy |
-| endpointName | string| ![Optional](https://img.shields.io/badge/optional-4169E1) | Name of the SageMaker endpoint created by the construct |
+| endpointName | string| ![Optional](https://img.shields.io/badge/optional-4169E1) | Name of the SageMaker endpoint created by the construct. The construct will prepend 'jumpstart-' to the name of the endpoint. |
 | acceptEula | boolean| ![Optional](https://img.shields.io/badge/optional-4169E1) | Specifies agreement to the model end-user license agreement (EULA). The AcceptEula value must be explicitly defined as True in order to accept the EULA that the model requires. The user is responsible for reviewing and complying with any applicable license terms and making sure they are acceptable for their use case before downloading or using a model. |
 | instanceType | SageMakerInstanceType | ![Optional](https://img.shields.io/badge/optional-4169E1) | The ML compute instance type. If not provided, the default instance type will be used. This value is available in the [models spec](./jumpstart-model.ts) |
 | instanceCount | Integer | ![Optional](https://img.shields.io/badge/optional-4169E1) | Number of instances to launch initially |

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/README_jumpstart.md
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/README_jumpstart.md
@@ -98,7 +98,7 @@ Parameters
 | **Name**     | **Type**        | **Required** |**Description** |
 |:-------------|:----------------|-----------------|-----------------|
 | model | JumpStartModel | ![Required](https://img.shields.io/badge/required-ff0000) | The model to deploy |
-| endpointName | string| ![Optional](https://img.shields.io/badge/optional-4169E1) | Name of the SageMaker endpoint created by the construct. The construct will prepend 'jumpstart-' to the name of the endpoint. |
+| endpointName | string| ![Required](https://img.shields.io/badge/required-ff0000) | Name of the SageMaker endpoint created by the construct. The construct will prepend 'jumpstart-' to the name of the endpoint. |
 | acceptEula | boolean| ![Optional](https://img.shields.io/badge/optional-4169E1) | Specifies agreement to the model end-user license agreement (EULA). The AcceptEula value must be explicitly defined as True in order to accept the EULA that the model requires. The user is responsible for reviewing and complying with any applicable license terms and making sure they are acceptable for their use case before downloading or using a model. |
 | instanceType | SageMakerInstanceType | ![Optional](https://img.shields.io/badge/optional-4169E1) | The ML compute instance type. If not provided, the default instance type will be used. This value is available in the [models spec](./jumpstart-model.ts) |
 | instanceCount | Integer | ![Optional](https://img.shields.io/badge/optional-4169E1) | Number of instances to launch initially |

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/jumpstart-sagemaker-endpoint.ts
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/jumpstart-sagemaker-endpoint.ts
@@ -21,7 +21,7 @@ import { SageMakerInstanceType } from './sagemaker-instance-type';
 
 export interface JumpStartSageMakerEndpointProps {
   readonly model: JumpStartModel;
-  readonly endpointName?: string;
+  readonly endpointName: string;
   readonly instanceType?: SageMakerInstanceType;
   readonly instanceCount?: number;
   readonly role?: iam.Role;

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/jumpstart-sagemaker-endpoint.ts
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/jumpstart-sagemaker-endpoint.ts
@@ -113,7 +113,7 @@ export class JumpStartSageMakerEndpoint extends SageMakerEndpointBase {
 
     const endpoint = new sagemaker.CfnEndpoint(scope, `${this.spec.modelId}-endpoint-${id}`, {
       endpointConfigName: endpointConfig.getAtt('EndpointConfigName').toString(),
-      endpointName: props.endpointName,
+      endpointName: 'jumpstart-'+props.endpointName,
     });
 
     endpoint.addDependency(endpointConfig);

--- a/test/patterns/gen-ai/aws-model-deployment-sagemaker/aws-model-deployment-sagemaker.test.ts
+++ b/test/patterns/gen-ai/aws-model-deployment-sagemaker/aws-model-deployment-sagemaker.test.ts
@@ -41,6 +41,7 @@ describe('JumpStartSageMakerEndpoint construct', () => {
       model: JumpStartModel.META_TEXTGENERATION_LLAMA_2_7B_F_2_0_2,
       acceptEula: true,
       instanceType: SageMakerInstanceType.ML_G5_2XLARGE,
+      endpointName: 'testendpoint',
     });
     JmpStrtTestTemplate = Template.fromStack(JmpStrtTestStack);
 
@@ -115,6 +116,7 @@ describe('JumpStartSageMakerEndpoint eula validation', () => {
         model: JumpStartModel.META_TEXTGENERATION_LLAMA_2_7B_F_2_0_2,
         acceptEula: false, // should fail synth
         instanceType: SageMakerInstanceType.ML_G5_2XLARGE,
+        endpointName: 'testendpoint',
       });
     };
 
@@ -129,6 +131,7 @@ describe('JumpStartSageMakerEndpoint eula validation', () => {
         model: JumpStartModel.META_TEXTGENERATION_LLAMA_2_7B_F_2_0_2,
         acceptEula: true, // should succeed synth
         instanceType: SageMakerInstanceType.ML_G5_2XLARGE,
+        endpointName: 'testendpoint',
       });
     };
 
@@ -142,6 +145,7 @@ describe('JumpStartSageMakerEndpoint eula validation', () => {
       new JumpStartSageMakerEndpoint(JmpStrtTestStack, 'test3', {
         model: JumpStartModel.MODEL_DEPTH2IMG_STABLE_DIFFUSION_V1_5_CONTROLNET_1_0_0, // eula not defined
         instanceType: SageMakerInstanceType.ML_G5_2XLARGE,
+        endpointName: 'testendpoint',
       });
     };
 
@@ -200,6 +204,7 @@ describe('JumpStartSageMakerEndpoint VPC construct', () => {
       model: JumpStartModel.META_TEXTGENERATION_LLAMA_2_7B_F_2_0_2,
       instanceType: SageMakerInstanceType.ML_G5_2XLARGE,
       acceptEula: true,
+      endpointName: 'testendpoint',
       vpcConfig: {
         securityGroupIds: securityGroups.map(s => s.securityGroupId),
         subnets: vpc.privateSubnets.map((subnet) => subnet.subnetId),


### PR DESCRIPTION
Fixes #

- prepend 'jumpstart-' to the endpoint name deployed by the construct
- make the property ```endpoint name``` required 
- update tests and documentation
- tested with the samples through a local build of the constructs, will update the associated sample once this is merged

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
