### PR TITLE
feat(versionupgrade): bump langchain version from 0.1.14 to 0.1.11

### DIFF
--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/requirements.txt
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/requirements.txt
@@ -9,6 +9,6 @@ requests==2.31.0
 requests-aws4auth==1.2.3
 opensearch-py==2.4.2
 numpy
-langchain==0.1.4
-langchain-community==0.0.16
+langchain==0.1.11
+langchain-community<0.1, >0.0.25
 opensearch-py

--- a/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/requirements.txt
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/requirements.txt
@@ -6,8 +6,8 @@ boto3>=1.34.29
 botocore>=1.34.29
 requests==2.31.0
 requests-aws4auth==1.2.3
-langchain==0.1.4
-langchain-community==0.0.16
+langchain==0.1.11
+langchain-community<0.1, >0.0.25
 opensearch-py==2.4.2
 sagemaker
 numpy

--- a/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/requirements.txt
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/s3_file_transformer/src/requirements.txt
@@ -4,5 +4,5 @@ fastjsonschema
 typing-extensions
 boto3
 requests
-langchain==0.1.4
+langchain==0.1.11
 pypdf2

--- a/lambda/aws-summarization-appsync-stepfn/document_reader/requirements.txt
+++ b/lambda/aws-summarization-appsync-stepfn/document_reader/requirements.txt
@@ -1,6 +1,6 @@
 redis
 pypdf2
-langchain==0.1.4
+langchain==0.1.11
 urllib3<2
 aws-xray-sdk
 aws-lambda-powertools

--- a/lambda/aws-summarization-appsync-stepfn/summary_generator/requirements.txt
+++ b/lambda/aws-summarization-appsync-stepfn/summary_generator/requirements.txt
@@ -3,7 +3,7 @@ boto3>=1.34.29
 botocore>=1.34.29
 requests==2.31.0
 requests-aws4auth==1.2.3
-langchain==0.1.4
+langchain==0.1.11
 nltk==3.8.1
 urllib3<2
 aws-lambda-powertools


### PR DESCRIPTION
Fixes #
Bumped langchain version from 0.1.14 to 0.1.11
Bumped dependent langchain-community to <0.1, >0.0.25
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
