### PR TITLE
chore(qa): refactor text qa to add support for additional models and fix issues

### DIFF
--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/__init__.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/__init__.py
@@ -1,0 +1,1 @@
+from .bedrock import *

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/base/__init__.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/base/__init__.py
@@ -1,0 +1,1 @@
+from .base import ModelAdapter

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/base/base.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/base/base.py
@@ -1,0 +1,45 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+import os
+from langchain.callbacks.base import BaseCallbackHandler
+from langchain.prompts.prompt import PromptTemplate
+
+
+class ModelAdapter:
+    def __init__(self, callback=None, modality='Text', model_kwargs={}):
+        self.model_kwargs = model_kwargs
+        self.modality = modality
+
+        self.callback_handler = callback
+
+        self.llm = self.get_llm(model_kwargs)
+
+    def get_llm(self, model_kwargs={}):
+        raise ValueError("llm must be implemented")
+
+    def get_embeddings_model(self, model_kwargs={}):
+        raise ValueError("embeddings must be implemented")
+
+    def get_prompt(self):
+
+        template = """
+
+        The following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+        {context}
+
+        Question: {question}"""
+
+        prompt_template = PromptTemplate(template=template, input_variables=["context", "question"])
+
+        return prompt_template

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/__init__.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/__init__.py
@@ -1,0 +1,2 @@
+from .claude import *
+from .titan import *

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/claude.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/claude.py
@@ -1,0 +1,134 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+import boto3
+
+from langchain_community.llms import Bedrock
+from langchain_community.chat_models import BedrockChat
+from langchain.prompts.prompt import PromptTemplate
+
+from ..base import ModelAdapter
+from ..registry import registry
+
+
+class BedrockClaudeAdapter(ModelAdapter):
+    def __init__(self, model_id, *args, **kwargs):
+        self.model_id = model_id
+
+        super().__init__(*args, **kwargs)
+
+    def get_llm(self, model_kwargs={}):
+        bedrock = boto3.client('bedrock-runtime')
+
+        params = {}
+        if "temperature" in model_kwargs:
+            params["temperature"] = model_kwargs["temperature"]
+        if "top_p" in model_kwargs:
+            params["top_p"] = model_kwargs["top_p"]
+        if "max_tokens_to_sample" in model_kwargs:
+            params["max_tokens_to_sample"] = model_kwargs["max_tokens_to_sample"]
+        if "stop_sequences" in model_kwargs:
+            params["stop_sequences"] = model_kwargs["stop_sequences"]
+        if "top_k" in model_kwargs:
+            params["top_k"] = model_kwargs["top_k"]
+
+        params["anthropic_version"] = "bedrock-2023-05-31"
+
+        kwargs = {
+            "client": bedrock,
+            "model_id": self.model_id,
+            "model_kwargs": params,
+            "streaming": False 
+        }
+
+        if self.callback_handler:
+            kwargs["callbacks"] = self.callback_handler
+            kwargs["streaming"] = model_kwargs.get("streaming", False)
+
+        return Bedrock(
+            **kwargs
+        )
+
+    def get_prompt(self):
+        template = """
+
+        Human: Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+        {context}
+
+        Question: {question}
+
+        Assistant:"""
+
+        return PromptTemplate(
+            template=template, input_variables=["context", "question"]
+        )
+
+# For claude v3, at the moment we need to use BedrockChat
+class BedrockClaudev3Adapter(ModelAdapter):
+    def __init__(self, model_id, *args, **kwargs):
+        self.model_id = model_id
+
+        super().__init__(*args, **kwargs)
+
+    def get_llm(self, model_kwargs={}):
+        bedrock = boto3.client('bedrock-runtime')
+
+        params = {}
+        if "temperature" in model_kwargs:
+            params["temperature"] = model_kwargs["temperature"]
+        if "top_p" in model_kwargs:
+            params["top_p"] = model_kwargs["top_p"]
+        if "max_tokens" in model_kwargs:
+            params["max_tokens"] = model_kwargs["max_tokens"]
+        if "stop_sequences" in model_kwargs:
+            params["stop_sequences"] = model_kwargs["stop_sequences"]
+        if "top_k" in model_kwargs:
+            params["top_k"] = model_kwargs["top_k"]
+
+        params["anthropic_version"] = "bedrock-2023-05-31"
+
+        kwargs = {
+            "client": bedrock,
+            "model_id": self.model_id,
+            "model_kwargs": params,
+            "streaming": False 
+        }
+
+        if self.callback_handler:
+            kwargs["callbacks"] = self.callback_handler
+            kwargs["streaming"] = model_kwargs.get("streaming", False)
+
+        return BedrockChat(
+            **kwargs
+        )
+
+    def get_prompt(self):
+        template = """
+
+        Human: Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+        {context}
+
+        Question: {question}
+
+        Assistant:"""
+
+        return PromptTemplate(
+            template=template, input_variables=["context", "question"]
+        )
+
+
+# Register the adapter
+registry.register(r"^Bedrock.anthropic.claude-v2*", BedrockClaudeAdapter)
+registry.register(r"^Bedrock.anthropic.claude-instant*", BedrockClaudeAdapter)
+registry.register(r"^Bedrock.anthropic.claude-3*", BedrockClaudev3Adapter)

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/titan.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/titan.py
@@ -1,0 +1,76 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+import boto3
+from langchain.prompts.prompt import PromptTemplate
+
+from langchain_community.llms import Bedrock
+from langchain_community.embeddings import BedrockEmbeddings
+
+from ..base import ModelAdapter
+from ..registry import registry
+
+
+class BedrockTitanAdapter(ModelAdapter):
+    def __init__(self, model_id, *args, **kwargs):
+        self.model_id = model_id
+
+        super().__init__(*args, **kwargs)
+
+    def get_llm(self, model_kwargs={}):
+        bedrock = boto3.client('bedrock-runtime')
+
+        params = {}
+        if "temperature" in model_kwargs:
+            params["temperature"] = model_kwargs["temperature"]
+        if "topP" in model_kwargs:
+            params["topP"] = model_kwargs["topP"]
+        if "maxTokenCount" in model_kwargs:
+            params["maxTokenCount"] = model_kwargs["maxTokens"]
+        if "stopSequences" in model_kwargs:
+            params["stopSequences"] = model_kwargs["stopSequences"]
+
+        kwargs = {
+            "client": bedrock,
+            "model_id": self.model_id,
+            "model_kwargs": params,
+            "streaming": False 
+        }
+
+        if self.callback_handler:
+            kwargs["callbacks"] = self.callback_handler
+            kwargs["streaming"] = model_kwargs.get("streaming", False)
+
+        return Bedrock(
+            **kwargs
+        )
+    
+    def get_embeddings_model(self, model_kwargs={}):
+        bedrock = boto3.client('bedrock-runtime')
+
+        return BedrockEmbeddings(client=bedrock, model_id=self.model_id)
+
+    def get_prompt(self):
+        template = """Human: The following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.
+
+        {context}
+
+        Question: {question}
+
+        Assistant:"""
+
+        return PromptTemplate(
+            template=template, input_variables=["context", "question"]
+        )
+
+# Register the adapter
+registry.register(r"^Bedrock.amazon.titan*", BedrockTitanAdapter)

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/titan.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/bedrock/titan.py
@@ -73,4 +73,5 @@ class BedrockTitanAdapter(ModelAdapter):
         )
 
 # Register the adapter
-registry.register(r"^Bedrock.amazon.titan*", BedrockTitanAdapter)
+registry.register(r"^Bedrock.amazon.titan-t*", BedrockTitanAdapter)
+registry.register(r"^Bedrock.amazon.titan-e*", BedrockTitanAdapter)

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/registry/__init__.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/registry/__init__.py
@@ -1,0 +1,3 @@
+from .index import AdapterRegistry
+
+registry = AdapterRegistry()

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/registry/index.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/adapters/registry/index.py
@@ -1,0 +1,33 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+#
+import re
+
+class AdapterRegistry:
+    def __init__(self):
+        # The registry is a dictionary where:
+        # Keys are compiled regular expressions
+        # Values are model IDs
+        self.registry = {}
+
+    def register(self, regex, model_id):
+        # Compiles the regex and stores it in the registry
+        self.registry[re.compile(regex)] = model_id
+
+    def get_adapter(self, model):
+        # Iterates over the registered regexes
+        for regex, adapter in self.registry.items():
+            # If a match is found, returns the associated model ID
+            if regex.match(model):
+                return adapter
+        # If no match is found, returns None
+        return None

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/__init__.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/__init__.py
@@ -1,1 +1,1 @@
-from .text_generation_llm_selector import get_llm, get_max_tokens, get_embeddings_llm,get_bedrock_fm
+from .text_generation_llm_selector import get_max_tokens,get_bedrock_fm

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/types.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/types.py
@@ -1,0 +1,45 @@
+from enum import StrEnum
+
+class Modality(StrEnum):
+    TEXT = 'Text'
+    IMAGE = 'Image'
+
+class Provider(StrEnum):
+    BEDROCK = 'Bedrock'
+    SAGEMAKER = 'Sagemaker Endpoint'
+
+class BedrockModel(StrEnum):
+    # ANTHROPIC MODELS
+    ANTHROPIC_CLAUDE_V2_1 = 'anthropic.claude-v2:1',
+    ANTHROPIC_CLAUDE_V2 = 'anthropic.claude-v2',
+    ANTHROPIC_CLAUDE_V3_HAIKU_V1 = 'anthropic.claude-3-haiku-20240307-v1:0',
+    ANTHROPIC_CLAUDE_V3_SONNET_V1 = 'anthropic.claude-3-sonnet-20240229-v1:0',
+    ANTHROPIC_CLAUDE_INSTANT_V1 = 'anthropic.claude-instant-v1'
+    # AMAZON
+    AMAZON_TITAN_TEXT_LITE_V1 = 'amazon.titan-text-lite-v1',
+    AMAZON_TITAN_TEXT_EXPRESS_V1 = 'amazon.titan-text-express-v1',
+    AMAZON_TITAN_EMBED_IMAGE_V1 = 'amazon.titan-embed-image-v1',
+    AMAZON_TITAN_EMBED_TEXT_V1 = 'amazon.titan-embed-text-v1',
+    AMAZON_TITAN_IMAGE_GENERATOR_V1 = 'amazon.titan-image-generator-v1',
+
+MAX_TOKENS_MAP = {
+    Provider.BEDROCK+'.'+BedrockModel.ANTHROPIC_CLAUDE_V2_1 : 200000,
+    Provider.BEDROCK+'.'+BedrockModel.ANTHROPIC_CLAUDE_V2 : 100000,
+    Provider.BEDROCK+'.'+BedrockModel.ANTHROPIC_CLAUDE_V3_HAIKU_V1 : 200000,
+    Provider.BEDROCK+'.'+BedrockModel.ANTHROPIC_CLAUDE_V3_SONNET_V1 : 200000,
+    Provider.BEDROCK+'.'+BedrockModel.ANTHROPIC_CLAUDE_INSTANT_V1 : 100000,
+    Provider.BEDROCK+'.'+BedrockModel.AMAZON_TITAN_TEXT_LITE_V1 : 4000,
+    Provider.BEDROCK+'.'+BedrockModel.AMAZON_TITAN_TEXT_EXPRESS_V1 : 8000,
+    Provider.BEDROCK+'.'+BedrockModel.AMAZON_TITAN_EMBED_TEXT_V1: 8000,
+    Provider.BEDROCK+'.'+BedrockModel.AMAZON_TITAN_EMBED_IMAGE_V1: 128,
+    Provider.BEDROCK+'.'+BedrockModel.AMAZON_TITAN_IMAGE_GENERATOR_V1: 77,
+}
+
+
+
+
+
+
+
+
+

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/types.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/types.py
@@ -6,7 +6,7 @@ class Modality(StrEnum):
 
 class Provider(StrEnum):
     BEDROCK = 'Bedrock'
-    SAGEMAKER = 'SagemakerEndpoint'
+    SAGEMAKER = 'Sagemaker'
 
 class BedrockModel(StrEnum):
     # ANTHROPIC MODELS

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/types.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/llms/types.py
@@ -6,7 +6,7 @@ class Modality(StrEnum):
 
 class Provider(StrEnum):
     BEDROCK = 'Bedrock'
-    SAGEMAKER = 'Sagemaker Endpoint'
+    SAGEMAKER = 'SagemakerEndpoint'
 
 class BedrockModel(StrEnum):
     # ANTHROPIC MODELS

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/chain.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/chain.py
@@ -74,6 +74,11 @@ def run_question_answering(arguments):
 
             llm_response = run_qa_agent_rag_no_memory(arguments)
             return llm_response
+        
+        if response_generation_method == 'RAG':
+            logger.info('Running qa agent with a RAG approach')
+            llm_response = run_qa_agent_rag_no_memory(arguments)
+            return llm_response
 
         bucket_name = os.environ['INPUT_BUCKET']
 
@@ -101,17 +106,13 @@ def run_question_answering(arguments):
         logger.info(
             f'For the current question, we have a max model length of {model_max_tokens} and a document containing {document_number_of_tokens} tokens')
 
-        if response_generation_method == 'RAG':
-            logger.info('Running qa agent with a RAG approach')
-            llm_response = run_qa_agent_rag_no_memory(arguments)
+        # LONG CONTEXT
+        # why add 500 ? on top of the document content, we add the prompt. So we keep an extra 500 tokens of space just in case
+        if (document_number_of_tokens + 250) < model_max_tokens:
+            logger.info('Running qa agent with full document in context')
+            llm_response = run_qa_agent_from_single_document_no_memory(arguments)
         else:
-            # LONG CONTEXT
-            # why add 500 ? on top of the document content, we add the prompt. So we keep an extra 500 tokens of space just in case
-            if (document_number_of_tokens + 250) < model_max_tokens:
-                logger.info('Running qa agent with full document in context')
-                llm_response = run_qa_agent_from_single_document_no_memory(arguments)
-            else:
-                logger.info('Running qa agent with a RAG approach due to document size')
-                llm_response = run_qa_agent_rag_no_memory(arguments)
+            logger.info('Running qa agent with a RAG approach due to document size')
+            llm_response = run_qa_agent_rag_no_memory(arguments)
         return llm_response
     

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/chain.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/chain.py
@@ -18,6 +18,7 @@ import os
 import base64
 
 from langchain.chains import LLMChain
+from llms.types import Modality
 from llms import  get_max_tokens
 from typing import Any, Dict, List, Union
 from .s3inmemoryloader import S3FileLoaderInMemory
@@ -48,7 +49,7 @@ def run_question_answering(arguments):
     modality=qa_model.get('modality','Text')
     
     # Visual QA
-    if modality.lower()=='image': 
+    if modality == Modality.IMAGE: 
          logger.info("Running QA for Image modality")             
 
           # user didn't provide a image url as input, we use the RAG source against the entire knowledge base
@@ -95,7 +96,8 @@ def run_question_answering(arguments):
             return ''
 
         model_id=qa_model['modelId']
-        model_max_tokens = get_max_tokens(model_id)
+        model_provider=qa_model['provider']
+        model_max_tokens = get_max_tokens(model_provider+'.'+model_id)
         logger.info(
             f'For the current question, we have a max model length of {model_max_tokens} and a document containing {document_number_of_tokens} tokens')
 

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/doc_qa.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/doc_qa.py
@@ -149,7 +149,8 @@ def run_qa_agent_rag_no_memory(input_params):
     # --------------------------------------------------------------------------
     logger.info(f'output_file_name is :: {output_file_name}')
     if output_file_name:
-        source_documents = [doc for doc in source_documents if doc.metadata['source'] == output_file_name]
+        file_without_extension = os.path.splitext(output_file_name)[0]
+        source_documents = [doc for doc in source_documents if file_without_extension in doc.metadata['source']]
         logger.info(source_documents)
     status_variables['sources'] = list(set(doc.metadata['source'] for doc in source_documents))
 

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/doc_qa.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/doc_qa.py
@@ -85,7 +85,7 @@ def run_qa_agent_rag_no_memory(input_params):
 
     # get embeddings model
     em_model= input_params['embeddings_model']
-    em_model_id = em_model.get('modelId')
+    em_model_id = em_model.get('modelId',BedrockModel.AMAZON_TITAN_EMBED_TEXT_V1)
     em_model_args = em_model.get('model_kwargs', {})
     em_modality=em_model.get('modality', Modality.TEXT)
     em_model_provider=em_model.get("provider",Provider.BEDROCK)

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/doc_qa.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/doc_qa.py
@@ -66,16 +66,6 @@ def run_qa_agent_rag_no_memory(input_params):
     qa_modality=qa_model.get('modality', Modality.TEXT)
     model_provider=qa_model.get("provider",Provider.BEDROCK) 
 
-    try:
-        json_qa_model_args = json.loads(qa_model_args)
-    except:
-        logger.error(f"Model args not properly formed {model_provider}.{qa_model_id}")
-        status_variables['jobstatus'] = JobStatus.ERROR_LOAD_ARGS.status
-        error = JobStatus.ERROR_LOAD_ARGS.get_message()
-        status_variables['answer'] = error.decode("utf-8")
-        send_job_status(status_variables)
-        return status_variables
-
     model_adapter = registry.get_adapter(f"{model_provider}.{qa_model_id}")
 
     if model_adapter is None:
@@ -90,7 +80,7 @@ def run_qa_agent_rag_no_memory(input_params):
         model_id=qa_model_id,
         callback=callback_manager,
         modality=qa_modality,
-        model_kwargs=json_qa_model_args,
+        model_kwargs=qa_model_args,
     )
 
     # get embeddings model
@@ -98,17 +88,7 @@ def run_qa_agent_rag_no_memory(input_params):
     em_model_id = em_model.get('modelId')
     em_model_args = em_model.get('model_kwargs', {})
     em_modality=em_model.get('modality', Modality.TEXT)
-    em_model_provider=em_model.get("provider",Provider.BEDROCK) 
-
-    try:
-        json_em_model_args = json.loads(em_model_args)
-    except:
-        logger.error(f"Model args not properly formed {model_provider}.{qa_model_id}")
-        status_variables['jobstatus'] = JobStatus.ERROR_LOAD_ARGS.status
-        error = JobStatus.ERROR_LOAD_ARGS.get_message()
-        status_variables['answer'] = error.decode("utf-8")
-        send_job_status(status_variables)
-        return status_variables
+    em_model_provider=em_model.get("provider",Provider.BEDROCK)
 
     embeddings_model_adapter = registry.get_adapter(f"{em_model_provider}.{em_model_id}")
 
@@ -123,7 +103,7 @@ def run_qa_agent_rag_no_memory(input_params):
     embeddings_model = embeddings_model_adapter(
         model_id=em_model_id,
         modality=qa_modality,
-        model_kwargs=json_em_model_args,
+        model_kwargs=em_model_args,
     )
 
     logger.info(decoded_question)
@@ -233,17 +213,7 @@ def run_qa_agent_from_single_document_no_memory(input_params):
     qa_model_id = qa_model.get('modelId')
     qa_model_args = qa_model.get('model_kwargs', {})
     qa_modality=qa_model.get('modality', 'Text')
-    model_provider=qa_model.get("provider",Provider.BEDROCK) 
-
-    try:
-        json_qa_model_args = json.loads(qa_model_args)
-    except:
-        logger.error(f"Model args not properly formed {model_provider}.{qa_model_id}")
-        status_variables['jobstatus'] = JobStatus.ERROR_LOAD_ARGS.status
-        error = JobStatus.ERROR_LOAD_ARGS.get_message()
-        status_variables['answer'] = error.decode("utf-8")
-        send_job_status(status_variables)
-        return status_variables
+    model_provider=qa_model.get("provider",Provider.BEDROCK)
 
     model_adapter = registry.get_adapter(f"{model_provider}.{qa_model_id}")
 
@@ -259,7 +229,7 @@ def run_qa_agent_from_single_document_no_memory(input_params):
         model_id=qa_model_id,
         callback=callback_manager,
         modality=qa_modality,
-        model_kwargs=json_qa_model_args,
+        model_kwargs=qa_model_args,
     )
 
     # 1 : load the document

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/helper.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/helper.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from aiohttp import ClientError
 from langchain_community.vectorstores import OpenSearchVectorSearch
 from opensearchpy import RequestsHttpConnection
-from llms import get_embeddings_llm
 import requests
 from enum import Enum
 from requests_aws4auth import AWS4Auth
@@ -52,6 +51,10 @@ class JobStatus(Enum):
     ERROR_LOAD_DOC = (
         'Failed to load document content',
         base64.b64encode("It seems I cannot load the document you are referring to, please verify that the document was correctly ingested or contect an administrator to get more information.".encode('utf-8'))
+    )
+    ERROR_LOAD_ARGS = (
+        'Failed to load the llm arguments provided', 
+        base64.b64encode("An internal error happened, and I am not able to load the args, please make sure the arguments provided are correctly structured.".encode('utf-8'))
     )
     ERROR_LOAD_LLM = (
         'Failed to load the llm', 
@@ -106,8 +109,7 @@ def load_vector_db_opensearch(region: str,
                               opensearch_domain_endpoint: str,
                               opensearch_index: str,
                               secret_id: str,
-                              model_id: str,
-                              modality: str) -> OpenSearchVectorSearch:
+                              llm) -> OpenSearchVectorSearch:
     logger.info(f"load_vector_db_opensearch, region={region}, "
                 f"opensearch_domain_endpoint={opensearch_domain_endpoint}, opensearch_index={opensearch_index}")
     
@@ -124,12 +126,11 @@ def load_vector_db_opensearch(region: str,
             opensearch_api_name,
             session_token=credentials.token,
         )
-    embedding_function = get_embeddings_llm(model_id,modality)
 
     opensearch_url = opensearch_domain_endpoint if opensearch_domain_endpoint.startswith("https://") else f"https://{opensearch_domain_endpoint}"
     
     vector_db = OpenSearchVectorSearch(index_name=opensearch_index,
-                                        embedding_function=embedding_function,
+                                        embedding_function=llm,
                                         opensearch_url=opensearch_url,
                                         http_auth=http_auth,
                                         use_ssl = True,

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/helper.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/helper.py
@@ -202,10 +202,10 @@ def download_file(bucket,key )-> str:
             logger.info(f"file downloaded {file_path}")
             return file_path
         except ClientError as client_err:
-            logger.error(f"Couldn\'t download file {client_err.response['Error']['Message']}")
+            logger.error(f"Couldn\'t download file {key}/{file_path} from {bucket}: {client_err.response['Error']['Message']}")
         
         except Exception as exp:
-            logger.error(f"Couldn\'t download file : {exp}")
+            logger.error(f"Couldn\'t download file {key}/{file_path} from {bucket}: {exp}")
  
 def encode_image_to_base64(image_file_path,image_file) -> str:
         with open(image_file_path, "rb") as image_file:

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/image_qa.py
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/qa_agent/image_qa.py
@@ -19,7 +19,7 @@ import base64
 import base64
 
 from llms import get_bedrock_fm
-from llms.types import Provider, Modality
+from llms.types import Provider, Modality, BedrockModel
 from langchain.prompts import PromptTemplate
 from langchain.chains import LLMChain
 from .sagemaker_endpoint import MultiModal
@@ -128,9 +128,9 @@ def run_qa_agent_rag_on_image_no_memory(input_params):
 def get_image_from_semantic_search_in_os(input_params,status_variables):
     
     em_model= input_params['embeddings_model']
-    em_model_id = em_model.get('modelId')
+    em_model_id = em_model.get('modelId',BedrockModel.AMAZON_TITAN_EMBED_IMAGE_V1)
     em_model_args = em_model.get('model_kwargs', {})
-    em_modality=em_model.get('modality', Modality.TEXT)
+    em_modality=em_model.get('modality', Modality.IMAGE)
     em_model_provider=em_model.get("provider",Provider.BEDROCK) 
 
     embeddings_model_adapter = registry.get_adapter(f"{em_model_provider}.{em_model_id}")

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/requirements.txt
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/requirements.txt
@@ -3,12 +3,12 @@ aws-xray-sdk
 fastjsonschema
 typing-extensions
 aiohttp
-boto3>=1.34.29
-botocore>=1.34.29
+boto3>=1.34.66
+botocore>=1.34.66
 requests==2.31.0
 requests-aws4auth==1.2.3
 opensearch-py==2.4.2
 numpy
-langchain==0.1.11
-langchain-community<0.1, >0.0.25
+langchain==0.1.13
+langchain-community==0.0.29
 opensearch-py

--- a/lambda/aws-qa-appsync-opensearch/question_answering/src/requirements.txt
+++ b/lambda/aws-qa-appsync-opensearch/question_answering/src/requirements.txt
@@ -1,5 +1,5 @@
-aws-lambda-powertools
-aws-xray-sdk
+aws-lambda-powertools==2.35.1
+aws-xray-sdk==2.13.0
 fastjsonschema
 typing-extensions
 aiohttp

--- a/resources/gen-ai/aws-qa-appsync-opensearch/schema.graphql
+++ b/resources/gen-ai/aws-qa-appsync-opensearch/schema.graphql
@@ -1,5 +1,5 @@
 enum ModelProvider {
-	Sagemaker Endpoint
+	Sagemaker
 	Bedrock
 }
 enum Modality {

--- a/resources/gen-ai/aws-rag-appsync-stepfn-opensearch/schema.graphql
+++ b/resources/gen-ai/aws-rag-appsync-stepfn-opensearch/schema.graphql
@@ -1,3 +1,8 @@
+enum ModelProvider {
+	Sagemaker Endpoint
+	Bedrock
+}
+
 type FileStatus @aws_iam @aws_cognito_user_pools {
 	name: String
 	status: String
@@ -5,7 +10,7 @@ type FileStatus @aws_iam @aws_cognito_user_pools {
 }
 
 input ModelConfiguration {
-	provider: String
+	provider: ModelProvider
 	modelId: String
 	streaming: Boolean
 	model_kwargs: AWSJSON

--- a/resources/gen-ai/aws-rag-appsync-stepfn-opensearch/schema.graphql
+++ b/resources/gen-ai/aws-rag-appsync-stepfn-opensearch/schema.graphql
@@ -1,5 +1,5 @@
 enum ModelProvider {
-	Sagemaker Endpoint
+	Sagemaker
 	Bedrock
 }
 

--- a/src/patterns/gen-ai/aws-qa-appsync-opensearch/README.md
+++ b/src/patterns/gen-ai/aws-qa-appsync-opensearch/README.md
@@ -28,6 +28,7 @@
   - [Initializer](#initializer)
   - [Pattern Construct Props](#pattern-construct-props)
   - [Pattern Properties](#pattern-properties)
+  - [Supported models](#supported-models)
   - [Default properties](#default-properties)
     - [Authentication](#authentication)
     - [Networking](#networking)
@@ -189,9 +190,11 @@ Mutation call to trigger the question:
     jobstatus: "", 
     qa_model: 
    	 {
+      provider: "Bedrock",
       modality: "Text",
       modelId: "anthropic.claude-v2:1", 
-      streaming: true
+      streaming: true,
+      model_kwargs: "{\"temperature\":0.5,\"top_p\":0.9,\"max_tokens_to_sample\":250}"
     },
     question:"d2hhdCBpcyBwcm9qZW4/",
     responseGenerationMethod: RAG
@@ -290,7 +293,29 @@ Parameters
 | s3InputAssetsBucketInterface | [s3.IBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)                                 | Returns an instance of s3.IBucket created by the construct                                                                                                                     |
 | s3InputAssetsBucket          | [s3.Bucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.Bucket.html)                                   | Returns an instance of s3.Bucket created by the construct. IMPORTANT: If existingInputAssetsBucketObj was provided in Pattern Construct Props, this property will be undefined |
 | graphqlApi                   | [appsync.IGraphqlApi](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_appsync.GraphqlApi.html)                | Returns an instance of appsync.IGraphqlApi created by the construct                                                                                                            |
-| qaLambdaFunction             | [lambda.DockerImageFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.DockerImageFunction.html) | Returns an instance of lambda.DockerImageFunction used for the question answering job created by the construct                                                                 |
+| qaLambdaFunction             | [lambda.DockerImageFunction](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.DockerImageFunction.html) | Returns an instance of lambda.DockerImageFunction used for the question answering job created by the construct  
+
+## Supported models
+
+Question answering
+
+| **Provider**  | **Model id** | **Modalities** | **Notes** |
+| :----------------------------- | :---- | ----- | --- |
+| Bedrock                          |  anthropic.claude-v2 | Text |  |
+| Bedrock                          |  anthropic.claude-v2:1 | Text |  |
+| Bedrock                          |  anthropic.claude-3-haiku-20240307-v1:0 | Text, Image |  |
+| Bedrock                          |  anthropic.claude-3-sonnet-20240229-v1:0 | Text, Image |  |
+| Bedrock                          |  anthropic.claude-instant-v1 | Text |  |
+| Bedrock                          |  amazon.titan-text-lite-v1 | Text |  |
+| Bedrock                          |  amazon.titan-text-express-v1 | Text |  |
+| SageMaker                          |  idefics | Text, Image | The model is not deployed as part of the construct and requires to be provisioned separately |
+
+Embeddings
+
+| **Provider**  | **Model id** | **Modalities** | **Notes** |
+| :----------------------------- | :---- | ----- | --- |
+| Bedrock                          |  amazon.titan-embed-image-v1 | Text |  |
+| Bedrock                          |  amazon.titan-embed-text-v1 | Text |  |
 
 ## Default properties
 


### PR DESCRIPTION
Fixes #

- refactor text qa to add support for new models, including Claude v3
- upgrade packages to get access to new upgrades in langchain
- fix issue where model args were not passed to the selected model
- fix graphql schema in rag preventing both qa and rag to be deployed together (conflicting input type)
- improve logging for image qa

Tested with all models supported, rag and long context, and tested image qa

In a next PR, will also refactor the image_qa to support the new structure and add missing models from Bedrock (mistral,...)

Eventually this code will move to a separate package to be used across the constructs

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
