### PR TITLE
fix(bedrock): create index with faiss and l2

### DIFF
--- a/lambda/opensearch-serverless-custom-resources/custom_resources/opensearch_index.py
+++ b/lambda/opensearch-serverless-custom-resources/custom_resources/opensearch_index.py
@@ -118,8 +118,8 @@ def create_mapping(
                 "type": "knn_vector",
                 "dimension": dimensions,
                 "method": {
-                    "engine": "nmslib",
-                    "space_type": "cosinesimil",
+                    "engine": "faiss",
+                    "space_type": "l2",
                     "name": "hnsw",
                     "parameters": {},
                 },


### PR DESCRIPTION
Fixes #349

New KB bedrock indexes use faiss.

CDK:
``` KnowledgeBase/KB: Received response status [FAILED] from custom resource. Message returned: Error: An error occurred (ValidationException) when calling the CreateKnowledgeBase operation: The knowledge base storage configuration provided is invalid... The OpenSearch Serverless engine type associated with your vector index is invalid. Recreate your vector index with one of the following valid engine types: FAISS. Then retry your request.```

New setup from AWS Console
<img width="1505" alt="Screenshot 2024-04-01 at 16 09 39" src="https://github.com/awslabs/generative-ai-cdk-constructs/assets/94814971/f79e6b11-b36e-4ed5-b70f-601fe9ba06d2">

