### PR TITLE
chore(github): fix github workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -20,5 +20,5 @@ jobs:
     steps:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
         with:
-          github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           review-message: Auto approved automated PR

--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -72,7 +72,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |-
             chore(deps): upgrade list of models and DLC images
             Upgrade list of models and DLC images. See details in [workflow run].

--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -72,7 +72,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             chore(deps): upgrade list of models and DLC images
             Upgrade list of models and DLC images. See details in [workflow run].

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -64,7 +64,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             chore(deps): upgrade dependencies
 

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -64,7 +64,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |-
             chore(deps): upgrade dependencies
 

--- a/projenrc/github-jobs.ts
+++ b/projenrc/github-jobs.ts
@@ -58,7 +58,7 @@ export function buildUpgradeMainPRCustomJob() {
         id: 'create-pr',
         uses: 'peter-evans/create-pull-request@v4',
         with: {
-          'token': '${{ secrets.GITHUB_TOKEN }}',
+          'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
           'commit-message': [
             'chore(deps): upgrade dependencies\n',
 

--- a/projenrc/github-jobs.ts
+++ b/projenrc/github-jobs.ts
@@ -58,7 +58,7 @@ export function buildUpgradeMainPRCustomJob() {
         id: 'create-pr',
         uses: 'peter-evans/create-pull-request@v4',
         with: {
-          'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
+          'token': '${{ secrets.GITHUB_TOKEN }}',
           'commit-message': [
             'chore(deps): upgrade dependencies\n',
 

--- a/projenrc/github-workflows.ts
+++ b/projenrc/github-workflows.ts
@@ -555,7 +555,7 @@ export function buildCodeGenerationWorkflow(project: AwsCdkConstructLibrary) {
         id: 'create-pr',
         uses: 'peter-evans/create-pull-request@v4',
         with: {
-          'token': '${{ secrets.GITHUB_TOKEN }}',
+          'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
           'commit-message': [
             'chore(deps): upgrade list of models and DLC images',
 

--- a/projenrc/github-workflows.ts
+++ b/projenrc/github-workflows.ts
@@ -157,7 +157,7 @@ export function buildAutoApproveWorkflow(project: AwsCdkConstructLibrary) {
       {
         uses: 'hmarr/auto-approve-action@v4.0.0',
         with: {
-          'github-token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
+          'github-token': '${{ secrets.GITHUB_TOKEN }}',
           'review-message': 'Auto approved automated PR',
         },
       },
@@ -555,7 +555,7 @@ export function buildCodeGenerationWorkflow(project: AwsCdkConstructLibrary) {
         id: 'create-pr',
         uses: 'peter-evans/create-pull-request@v4',
         with: {
-          'token': '${{ secrets.GITHUB_TOKEN }}',
+          'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
           'commit-message': [
             'chore(deps): upgrade list of models and DLC images',
 

--- a/projenrc/github-workflows.ts
+++ b/projenrc/github-workflows.ts
@@ -555,7 +555,7 @@ export function buildCodeGenerationWorkflow(project: AwsCdkConstructLibrary) {
         id: 'create-pr',
         uses: 'peter-evans/create-pull-request@v4',
         with: {
-          'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
+          'token': '${{ secrets.GITHUB_TOKEN }}',
           'commit-message': [
             'chore(deps): upgrade list of models and DLC images',
 


### PR DESCRIPTION
Fixes #

Following the documentation for https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-inputs, we cannot use the github action token for auto creation of PRs in our case. Reverting back the bot user to create the PRs automatically, and github-actions bot to auto approve

Now the behavior is the same as the cdk

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
