### PR TITLE
chore(bedrock): add support for claude 3 models in agents for bedrock

### DIFF
--- a/apidocs/classes/bedrock.BedrockFoundationModel.md
+++ b/apidocs/classes/bedrock.BedrockFoundationModel.md
@@ -21,10 +21,10 @@ can instantiate a `BedrockFoundationModel` object, e.g: `new BedrockFoundationMo
 - [supportsAgents](bedrock.BedrockFoundationModel.md#supportsagents)
 - [supportsKnowledgeBase](bedrock.BedrockFoundationModel.md#supportsknowledgebase)
 - [vectorDimensions](bedrock.BedrockFoundationModel.md#vectordimensions)
-- [AMAZON\_CLAUDE\_HAIKU\_V1\_0](bedrock.BedrockFoundationModel.md#amazon_claude_haiku_v1_0)
-- [AMAZON\_CLAUDE\_SONNET\_V1\_0](bedrock.BedrockFoundationModel.md#amazon_claude_sonnet_v1_0)
 - [AMAZON\_TITAN\_TEXT\_EXPRESS\_V1](bedrock.BedrockFoundationModel.md#amazon_titan_text_express_v1)
+- [ANTHROPIC\_CLAUDE\_HAIKU\_V1\_0](bedrock.BedrockFoundationModel.md#anthropic_claude_haiku_v1_0)
 - [ANTHROPIC\_CLAUDE\_INSTANT\_V1\_2](bedrock.BedrockFoundationModel.md#anthropic_claude_instant_v1_2)
+- [ANTHROPIC\_CLAUDE\_SONNET\_V1\_0](bedrock.BedrockFoundationModel.md#anthropic_claude_sonnet_v1_0)
 - [ANTHROPIC\_CLAUDE\_V2](bedrock.BedrockFoundationModel.md#anthropic_claude_v2)
 - [ANTHROPIC\_CLAUDE\_V2\_1](bedrock.BedrockFoundationModel.md#anthropic_claude_v2_1)
 - [COHERE\_EMBED\_ENGLISH\_V3](bedrock.BedrockFoundationModel.md#cohere_embed_english_v3)
@@ -79,27 +79,27 @@ ___
 
 ___
 
-### AMAZON\_CLAUDE\_HAIKU\_V1\_0
-
-▪ `Static` `Readonly` **AMAZON\_CLAUDE\_HAIKU\_V1\_0**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
-
-___
-
-### AMAZON\_CLAUDE\_SONNET\_V1\_0
-
-▪ `Static` `Readonly` **AMAZON\_CLAUDE\_SONNET\_V1\_0**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
-
-___
-
 ### AMAZON\_TITAN\_TEXT\_EXPRESS\_V1
 
 ▪ `Static` `Readonly` **AMAZON\_TITAN\_TEXT\_EXPRESS\_V1**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
 
 ___
 
+### ANTHROPIC\_CLAUDE\_HAIKU\_V1\_0
+
+▪ `Static` `Readonly` **ANTHROPIC\_CLAUDE\_HAIKU\_V1\_0**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
+
+___
+
 ### ANTHROPIC\_CLAUDE\_INSTANT\_V1\_2
 
 ▪ `Static` `Readonly` **ANTHROPIC\_CLAUDE\_INSTANT\_V1\_2**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
+
+___
+
+### ANTHROPIC\_CLAUDE\_SONNET\_V1\_0
+
+▪ `Static` `Readonly` **ANTHROPIC\_CLAUDE\_SONNET\_V1\_0**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
 
 ___
 

--- a/apidocs/classes/bedrock.BedrockFoundationModel.md
+++ b/apidocs/classes/bedrock.BedrockFoundationModel.md
@@ -21,6 +21,8 @@ can instantiate a `BedrockFoundationModel` object, e.g: `new BedrockFoundationMo
 - [supportsAgents](bedrock.BedrockFoundationModel.md#supportsagents)
 - [supportsKnowledgeBase](bedrock.BedrockFoundationModel.md#supportsknowledgebase)
 - [vectorDimensions](bedrock.BedrockFoundationModel.md#vectordimensions)
+- [AMAZON\_CLAUDE\_HAIKU\_V1\_0](bedrock.BedrockFoundationModel.md#amazon_claude_haiku_v1_0)
+- [AMAZON\_CLAUDE\_SONNET\_V1\_0](bedrock.BedrockFoundationModel.md#amazon_claude_sonnet_v1_0)
 - [AMAZON\_TITAN\_TEXT\_EXPRESS\_V1](bedrock.BedrockFoundationModel.md#amazon_titan_text_express_v1)
 - [ANTHROPIC\_CLAUDE\_INSTANT\_V1\_2](bedrock.BedrockFoundationModel.md#anthropic_claude_instant_v1_2)
 - [ANTHROPIC\_CLAUDE\_V2](bedrock.BedrockFoundationModel.md#anthropic_claude_v2)
@@ -74,6 +76,18 @@ ___
 ### vectorDimensions
 
 • `Optional` `Readonly` **vectorDimensions**: `number`
+
+___
+
+### AMAZON\_CLAUDE\_HAIKU\_V1\_0
+
+▪ `Static` `Readonly` **AMAZON\_CLAUDE\_HAIKU\_V1\_0**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
+
+___
+
+### AMAZON\_CLAUDE\_SONNET\_V1\_0
+
+▪ `Static` `Readonly` **AMAZON\_CLAUDE\_SONNET\_V1\_0**: [`BedrockFoundationModel`](bedrock.BedrockFoundationModel.md)
 
 ___
 

--- a/src/cdk-lib/bedrock/models.ts
+++ b/src/cdk-lib/bedrock/models.ts
@@ -57,11 +57,11 @@ export class BedrockFoundationModel {
     'amazon.titan-text-express-v1',
     { supportsAgents: true },
   );
-  public static readonly AMAZON_CLAUDE_SONNET_V1_0 = new BedrockFoundationModel(
+  public static readonly ANTHROPIC_CLAUDE_SONNET_V1_0 = new BedrockFoundationModel(
     'anthropic.claude-3-sonnet-20240229-v1:0',
     { supportsAgents: true },
   );
-  public static readonly AMAZON_CLAUDE_HAIKU_V1_0 = new BedrockFoundationModel(
+  public static readonly ANTHROPIC_CLAUDE_HAIKU_V1_0 = new BedrockFoundationModel(
     'anthropic.claude-3-haiku-20240307-v1:0',
     { supportsAgents: true },
   );

--- a/src/cdk-lib/bedrock/models.ts
+++ b/src/cdk-lib/bedrock/models.ts
@@ -57,6 +57,14 @@ export class BedrockFoundationModel {
     'amazon.titan-text-express-v1',
     { supportsAgents: true },
   );
+  public static readonly AMAZON_CLAUDE_SONNET_V1_0 = new BedrockFoundationModel(
+    'anthropic.claude-3-sonnet-20240229-v1:0',
+    { supportsAgents: true },
+  );
+  public static readonly AMAZON_CLAUDE_HAIKU_V1_0 = new BedrockFoundationModel(
+    'anthropic.claude-3-haiku-20240307-v1:0',
+    { supportsAgents: true },
+  );
 
   public static readonly TITAN_EMBED_TEXT_V1 = new BedrockFoundationModel(
     'amazon.titan-embed-text-v1',


### PR DESCRIPTION
Fixes #404 

Add support for claude 3 sonnet and haiku in agents for bedrock
Tested with the bedrock sample available here: https://github.com/aws-samples/generative-ai-cdk-constructs-samples/tree/main/samples/bedrock-agent
Deployed and tested the sample with each one of the new models

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
