### PR TITLE
Ingestion was failing as model_id parameter is not passed

### DIFF
--- a/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/lambda.py
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/lambda.py
@@ -106,7 +106,8 @@ def process_documents_in_es(index_exists, shards, http_auth,model_id):
         results = process_shard(shard=shard,
                     os_index_name=opensearch_index,
                     os_domain_ep=opensearch_domain,
-                    os_http_auth=http_auth)
+                    os_http_auth=http_auth,
+                    model_id=model_id)
 
 def process_documents_in_aoss(index_exists, shards, http_auth,model_id):
     bedrock_client = boto3.client('bedrock-runtime')


### PR DESCRIPTION
Fixes #
When trying to ingest a file statemachine has failed as shown below, due to model_id not being passed to the process_shard method. Added model_id as method param to fix the issue.
![image](https://github.com/awslabs/generative-ai-cdk-constructs/assets/101553100/9080cf28-7c4d-4af1-9968-870597b3d014)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
