### PR TITLE
fix: embedding_job is failing to generate embeddings

### DIFF
--- a/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/lambda.py
+++ b/lambda/aws-rag-appsync-stepfn-opensearch/embeddings_job/src/lambda.py
@@ -106,7 +106,8 @@ def process_documents_in_es(index_exists, shards, http_auth,model_id):
         results = process_shard(shard=shard,
                     os_index_name=opensearch_index,
                     os_domain_ep=opensearch_domain,
-                    os_http_auth=http_auth)
+                    os_http_auth=http_auth,
+                    model_id=model_id)
 
 def process_documents_in_aoss(index_exists, shards, http_auth,model_id):
     bedrock_client = boto3.client('bedrock-runtime')


### PR DESCRIPTION
When trying to ingest a file Step function state machine is failing at "generate embeddings from processed documents and store them" with the error : "process_shard() missing 1 required positional argument: model_id" updated code to pass model_id to process_shard() method
![image](https://github.com/awslabs/generative-ai-cdk-constructs/assets/101553100/513f2a16-c9e3-4833-9d0e-fe7ffcc98940)

Fixes #
Issue - process_shard() missing 1 required positional argument: model_id
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
