### PR TITLE
feat(construct): added enableUserInput prop on agent

### DIFF
--- a/apidocs/interfaces/bedrock.AgentProps.md
+++ b/apidocs/interfaces/bedrock.AgentProps.md
@@ -13,6 +13,7 @@ Properties for a Bedrock Agent.
 - [actionGroups](bedrock.AgentProps.md#actiongroups)
 - [aliasName](bedrock.AgentProps.md#aliasname)
 - [description](bedrock.AgentProps.md#description)
+- [enableUserInput](bedrock.AgentProps.md#enableuserinput)
 - [encryptionKey](bedrock.AgentProps.md#encryptionkey)
 - [foundationModel](bedrock.AgentProps.md#foundationmodel)
 - [idleSessionTTL](bedrock.AgentProps.md#idlesessionttl)
@@ -63,6 +64,22 @@ A description of the agent.
 
 ```ts
 - No description is provided.
+```
+
+___
+
+### enableUserInput
+
+• `Optional` `Readonly` **enableUserInput**: `boolean`
+
+Select whether the agent can prompt additional
+information from the user when it does not have
+enough information to respond to an utterance
+
+**`Default`**
+
+```ts
+- False
 ```
 
 ___

--- a/src/cdk-lib/bedrock/agent.ts
+++ b/src/cdk-lib/bedrock/agent.ts
@@ -235,6 +235,16 @@ export interface AgentProps {
    */
   readonly actionGroups?: AgentActionGroup[];
 
+
+  /**
+   * Select whether the agent can prompt additional
+   * information from the user when it does not have
+   * enough information to respond to an utterance
+   *
+   * @default - False
+   */
+  readonly enableUserInput?: boolean;
+
   /**
    * How long sessions should be kept open for the agent.
    *
@@ -443,6 +453,15 @@ export class Agent extends Construct {
 
     if (props.actionGroups) {
       this.addActionGroups(props.actionGroups);
+    }
+    // To allow your agent to request the user for additional information
+    // when trying to complete a task , add this action group
+    if (props.enableUserInput) {
+      this.addActionGroup(new AgentActionGroup(this, 'userInputEnabledActionGroup', {
+        actionGroupName: 'UserInputAction',
+        parentActionGroupSignature: 'AMAZON.UserInput',
+        actionGroupState: 'ENABLED',
+      }));
     }
   }
 


### PR DESCRIPTION
Fixes #
1. Added enableUserInput prop in Agent. (https://github.com/awslabs/generative-ai-cdk-constructs/issues/272)
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
