### PR TITLE
feat: add additional props for opensearch serverless and bedrock

### DIFF
--- a/apidocs/classes/opensearchserverless.VectorCollection.md
+++ b/apidocs/classes/opensearchserverless.VectorCollection.md
@@ -29,6 +29,7 @@ It includes all policies.
 - [dataAccessPolicy](opensearchserverless.VectorCollection.md#dataaccesspolicy)
 - [dataAccessPolicyDocument](opensearchserverless.VectorCollection.md#dataaccesspolicydocument)
 - [node](opensearchserverless.VectorCollection.md#node)
+- [standbyReplicas](opensearchserverless.VectorCollection.md#standbyreplicas)
 
 ### Methods
 
@@ -40,7 +41,7 @@ It includes all policies.
 
 ### constructor
 
-• **new VectorCollection**(`scope`, `id`): [`VectorCollection`](opensearchserverless.VectorCollection.md)
+• **new VectorCollection**(`scope`, `id`, `props?`): [`VectorCollection`](opensearchserverless.VectorCollection.md)
 
 #### Parameters
 
@@ -48,6 +49,7 @@ It includes all policies.
 | :------ | :------ |
 | `scope` | `Construct` |
 | `id` | `string` |
+| `props?` | [`VectorCollectionProps`](../interfaces/opensearchserverless.VectorCollectionProps.md) |
 
 #### Returns
 
@@ -116,6 +118,14 @@ The tree node.
 #### Inherited from
 
 Construct.node
+
+___
+
+### standbyReplicas
+
+• **standbyReplicas**: [`VectorCollectionStandbyReplicas`](../enums/opensearchserverless.VectorCollectionStandbyReplicas.md)
+
+Indicates whether to use standby replicas for the collection.
 
 ## Methods
 

--- a/apidocs/enums/opensearchserverless.VectorCollectionStandbyReplicas.md
+++ b/apidocs/enums/opensearchserverless.VectorCollectionStandbyReplicas.md
@@ -1,0 +1,24 @@
+[@cdklabs/generative-ai-cdk-constructs](../README.md) / [opensearchserverless](../modules/opensearchserverless.md) / VectorCollectionStandbyReplicas
+
+# Enumeration: VectorCollectionStandbyReplicas
+
+[opensearchserverless](../modules/opensearchserverless.md).VectorCollectionStandbyReplicas
+
+## Table of contents
+
+### Enumeration Members
+
+- [DISABLED](opensearchserverless.VectorCollectionStandbyReplicas.md#disabled)
+- [ENABLED](opensearchserverless.VectorCollectionStandbyReplicas.md#enabled)
+
+## Enumeration Members
+
+### DISABLED
+
+• **DISABLED** = ``"DISABLED"``
+
+___
+
+### ENABLED
+
+• **ENABLED** = ``"ENABLED"``

--- a/apidocs/interfaces/bedrock.KnowledgeBaseProps.md
+++ b/apidocs/interfaces/bedrock.KnowledgeBaseProps.md
@@ -15,6 +15,7 @@ Properties for a knowledge base
 - [indexName](bedrock.KnowledgeBaseProps.md#indexname)
 - [instruction](bedrock.KnowledgeBaseProps.md#instruction)
 - [knowledgeBaseState](bedrock.KnowledgeBaseProps.md#knowledgebasestate)
+- [name](bedrock.KnowledgeBaseProps.md#name)
 - [tags](bedrock.KnowledgeBaseProps.md#tags)
 - [vectorField](bedrock.KnowledgeBaseProps.md#vectorfield)
 - [vectorIndex](bedrock.KnowledgeBaseProps.md#vectorindex)
@@ -82,6 +83,14 @@ ___
 • `Optional` `Readonly` **knowledgeBaseState**: `string`
 
 Specifies whether to use the knowledge base or not when sending an InvokeAgent request.
+
+___
+
+### name
+
+• `Optional` `Readonly` **name**: `string`
+
+The name of the knowledge base.
 
 ___
 

--- a/apidocs/interfaces/opensearchserverless.VectorCollectionProps.md
+++ b/apidocs/interfaces/opensearchserverless.VectorCollectionProps.md
@@ -1,0 +1,34 @@
+[@cdklabs/generative-ai-cdk-constructs](../README.md) / [opensearchserverless](../modules/opensearchserverless.md) / VectorCollectionProps
+
+# Interface: VectorCollectionProps
+
+[opensearchserverless](../modules/opensearchserverless.md).VectorCollectionProps
+
+## Table of contents
+
+### Properties
+
+- [collectionName](opensearchserverless.VectorCollectionProps.md#collectionname)
+- [standbyReplicas](opensearchserverless.VectorCollectionProps.md#standbyreplicas)
+
+## Properties
+
+### collectionName
+
+• `Readonly` **collectionName**: `string`
+
+The name of the collection.
+
+___
+
+### standbyReplicas
+
+• `Optional` `Readonly` **standbyReplicas**: [`VectorCollectionStandbyReplicas`](../enums/opensearchserverless.VectorCollectionStandbyReplicas.md)
+
+Indicates whether to use standby replicas for the collection.
+
+**`Default`**
+
+```ts
+ENABLED
+```

--- a/apidocs/modules/opensearchserverless.md
+++ b/apidocs/modules/opensearchserverless.md
@@ -4,6 +4,14 @@
 
 ## Table of contents
 
+### Enumerations
+
+- [VectorCollectionStandbyReplicas](../enums/opensearchserverless.VectorCollectionStandbyReplicas.md)
+
 ### Classes
 
 - [VectorCollection](../classes/opensearchserverless.VectorCollection.md)
+
+### Interfaces
+
+- [VectorCollectionProps](../interfaces/opensearchserverless.VectorCollectionProps.md)

--- a/src/cdk-lib/bedrock/knowledge-base.ts
+++ b/src/cdk-lib/bedrock/knowledge-base.ts
@@ -100,6 +100,11 @@ export interface KnowledgeBaseProps {
   readonly embeddingsModel: BedrockFoundationModel;
 
   /**
+   * The name of the knowledge base.
+   */
+  readonly name?: string;
+
+  /**
    * The description of the knowledge base.
    *
    * @default - No description provided.
@@ -241,7 +246,7 @@ export class KnowledgeBase extends Construct {
     const textField = 'AMAZON_BEDROCK_TEXT_CHUNK';
     const metadataField = 'AMAZON_BEDROCK_METADATA';
 
-    this.description= props.description ?? 'CDK deployed Knowledge base'; // even though this prop is optional, if no value is provided it will fail to deploy
+    this.description = props.description ?? 'CDK deployed Knowledge base'; // even though this prop is optional, if no value is provided it will fail to deploy
     this.knowledgeBaseState = props.knowledgeBaseState ?? 'ENABLED';
 
 
@@ -251,10 +256,11 @@ export class KnowledgeBase extends Construct {
       validateIndexParameters(props.vectorIndex, indexName, vectorField);
     }
 
-    this.name = generatePhysicalNameV2(
+    this.name = props.name ?? generatePhysicalNameV2(
       this,
       'KB',
       { maxLength: 32 });
+
     const roleName = generatePhysicalNameV2(
       this,
       'AmazonBedrockExecutionRoleForKnowledgeBase',
@@ -422,7 +428,7 @@ export class KnowledgeBase extends Construct {
       tags: props.tags,
     });
 
-    this.knowledgeBaseInstance=knowledgeBase;
+    this.knowledgeBaseInstance = knowledgeBase;
 
     const kbCRPolicy = new iam.Policy(this, 'KBCRPolicy', {
       // roles: [crProvider.role],
@@ -583,8 +589,7 @@ export class KnowledgeBase extends Construct {
    * @returns The instance of VectorCollection, VectorStoreType.
    * @internal This is an internal core function and should not be called directly.
    */
-  private handleOpenSearchDefaultVectorCollection():
-  {
+  private handleOpenSearchDefaultVectorCollection(): {
     vectorStore: VectorCollection;
     vectorStoreType: VectorStoreType;
   } {
@@ -606,7 +611,7 @@ export class KnowledgeBase extends Construct {
       knowledgeBaseId: this.knowledgeBaseId,
       knowledgeBaseState: this.knowledgeBaseState,
     };
-    agent.knowledgeBases=[agentKnowledgeBaseProperty];
+    agent.knowledgeBases = [agentKnowledgeBaseProperty];
   }
 }
 
@@ -636,15 +641,15 @@ function validateVectorIndex(
 ) {
   if (!(vectorStore instanceof VectorCollection) && vectorIndex) {
     throw new Error('If vectorStore is not of type VectorCollection, vectorIndex should not be provided ' +
-    'in KnowledgeBase construct.');
+      'in KnowledgeBase construct.');
   }
   if (!(vectorStore instanceof VectorCollection) && indexName) {
     throw new Error('If vectorStore is not of type VectorCollection, indexName should not be provided ' +
-    'in KnowledgeBase construct.');
+      'in KnowledgeBase construct.');
   }
   if (!(vectorStore instanceof VectorCollection) && vectorField) {
     throw new Error('If vectorStore is not of type VectorCollection, vectorField should not be provided ' +
-    'in KnowledgeBase construct.');
+      'in KnowledgeBase construct.');
   }
 }
 
@@ -667,19 +672,19 @@ function validateIndexParameters(
   if (vectorIndex.indexName !== 'bedrock-knowledge-base-default-index') {
     if (vectorIndex.indexName !== indexName) {
       throw new Error('Default value of indexName is `bedrock-knowledge-base-default-index`.' +
-      ' If you create VectorIndex manually and assign vectorIndex to value other than' +
-      ' `bedrock-knowledge-base-default-index` then you must provide the same value in KnowledgeBase construct.' +
-      ' If you created VectorIndex manually and set it to `bedrock-knowledge-base-default-index`' +
-      ' then do not assign indexName in KnowledgeBase construct.');
+        ' If you create VectorIndex manually and assign vectorIndex to value other than' +
+        ' `bedrock-knowledge-base-default-index` then you must provide the same value in KnowledgeBase construct.' +
+        ' If you created VectorIndex manually and set it to `bedrock-knowledge-base-default-index`' +
+        ' then do not assign indexName in KnowledgeBase construct.');
     }
   }
   if (vectorIndex.vectorField !== 'bedrock-knowledge-base-default-vector') {
     if (vectorIndex.vectorField !== vectorField) {
       throw new Error('Default value of vectorField is `bedrock-knowledge-base-default-vector`.' +
-      ' If you create VectorIndex manually and assign vectorField to value other than' +
-      ' `bedrock-knowledge-base-default-field` then you must provide the same value in KnowledgeBase construct.' +
-      ' If you created VectorIndex manually and set it to `bedrock-knowledge-base-default-vector`' +
-      ' then do not assign vectorField in KnowledgeBase construct.');
+        ' If you create VectorIndex manually and assign vectorField to value other than' +
+        ' `bedrock-knowledge-base-default-field` then you must provide the same value in KnowledgeBase construct.' +
+        ' If you created VectorIndex manually and set it to `bedrock-knowledge-base-default-vector`' +
+        ' then do not assign vectorField in KnowledgeBase construct.');
     }
   }
 }

--- a/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
+++ b/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
@@ -540,6 +540,7 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
       ],
       "Properties": {
         "Name": "vectorstoreteststectors7d46d76b",
+        "StandbyReplicas": "ENABLED",
         "Type": "VECTORSEARCH",
       },
       "Type": "AWS::OpenSearchServerless::Collection",

--- a/test/cdk-lib/bedrock/knowledge-base.test.ts
+++ b/test/cdk-lib/bedrock/knowledge-base.test.ts
@@ -104,12 +104,14 @@ describe('KnowledgeBase', () => {
       embeddingsModel: model,
       vectorStore: vectorStore,
       instruction: 'Test instruction',
+      name: 'TestKnowledgeBase',
     });
 
     expect(knowledgeBase.instruction).toBe('Test instruction');
     expect(knowledgeBase.name).toBeDefined();
     expect(knowledgeBase.role).toBeDefined();
     expect(knowledgeBase.vectorStore).toBe(vectorStore);
+    expect(knowledgeBase.name).toBe('TestKnowledgeBase');
   });
 
   test('Should correctly initialize role with necessary permissions', () => {

--- a/test/cdk-lib/bedrock/knowledge-base.test.ts
+++ b/test/cdk-lib/bedrock/knowledge-base.test.ts
@@ -96,10 +96,10 @@ describe('KnowledgeBase', () => {
   });
 
   test('Should correctly initialize with custom props', () => {
-    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AuroraDefaultVectorStore6', {
-      embeddingsModelVectorDimension: BedrockFoundationModel.TITAN_EMBED_TEXT_V1.vectorDimensions!,
-    });
     const model = BedrockFoundationModel.TITAN_EMBED_TEXT_V1;
+    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AuroraDefaultVectorStore6', {
+      embeddingsModelVectorDimension: model.vectorDimensions!,
+    });
     const knowledgeBase = new KnowledgeBase(stack, 'AuroraDefaultKnowledgeBase', {
       embeddingsModel: model,
       vectorStore: vectorStore,
@@ -131,10 +131,10 @@ describe('KnowledgeBase', () => {
   });
 
   test('Should throw error when vectorStore is not VectorCollection and indexName is provided', () => {
-    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AmazonAuroraDefaultVectorStore6', {
-      embeddingsModelVectorDimension: BedrockFoundationModel.TITAN_EMBED_TEXT_V1.vectorDimensions!,
-    });
     const model = BedrockFoundationModel.TITAN_EMBED_TEXT_V1;
+    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AmazonAuroraDefaultVectorStore6', {
+      embeddingsModelVectorDimension: model.vectorDimensions!,
+    });
 
     expect(() => {
       new KnowledgeBase(stack, 'AuroraDefaultKnowledgeBase6', {
@@ -146,10 +146,10 @@ describe('KnowledgeBase', () => {
   });
 
   test('Should throw error when vectorStore is not VectorCollection and vectorField is provided', () => {
-    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AmazonAuroraDefaultVectorStore5', {
-      embeddingsModelVectorDimension: BedrockFoundationModel.TITAN_EMBED_TEXT_V1.vectorDimensions!,
-    });
     const model = BedrockFoundationModel.TITAN_EMBED_TEXT_V1;
+    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AmazonAuroraDefaultVectorStore5', {
+      embeddingsModelVectorDimension: model.vectorDimensions!,
+    });
 
     expect(() => {
       new KnowledgeBase(stack, 'AuroraDefaultKnowledgeBase5', {
@@ -189,10 +189,10 @@ describe('KnowledgeBase', () => {
   });
 
   test('Should correctly initialize with AmazonAuroraDefaultVectorStore and custom embeddingsModel', () => {
-    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AuroraDefaultVectorStore2', {
-      embeddingsModelVectorDimension: BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3.vectorDimensions!,
-    });
     const model = BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3;
+    const vectorStore = new AmazonAuroraDefaultVectorStore(stack, 'AuroraDefaultVectorStore2', {
+      embeddingsModelVectorDimension: model.vectorDimensions!,
+    });
 
     const knowledgeBase = new KnowledgeBase(stack, 'AuroraDefaultKnowledgeBase2', {
       embeddingsModel: model,


### PR DESCRIPTION
Fixes #459 

Added `collectionName?: string` prop to `VectorCollectionProps` interface.
---
Fixes #457 

Added `standbyReplicas`prop to `VectorCollectionProps` interface.
---
Fixes #458 

Added `name?: string` prop to `KnowledgeBaseProps` interface.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
