### PR TITLE
fix(bedrock): use CfnDataSource and construct's dataSourceId as unique id (fixes #470)

### DIFF
--- a/apidocs/classes/bedrock.S3DataSource.md
+++ b/apidocs/classes/bedrock.S3DataSource.md
@@ -55,7 +55,7 @@ Construct.constructor
 
 ### dataSource
 
-• `Readonly` **dataSource**: `CfnResource`
+• `Readonly` **dataSource**: `CfnDataSource`
 
 The Data Source cfn resource.
 

--- a/src/cdk-lib/bedrock/s3-data-source.ts
+++ b/src/cdk-lib/bedrock/s3-data-source.ts
@@ -11,7 +11,6 @@
  *  and limitations under the License.
  */
 
-import * as cdk from 'aws-cdk-lib';
 import { aws_bedrock as bedrock } from 'aws-cdk-lib';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -103,7 +102,7 @@ export class S3DataSource extends Construct {
   /**
    * The Data Source cfn resource.
    */
-  public readonly dataSource: cdk.CfnResource;
+  public readonly dataSource: bedrock.CfnDataSource;
   /**
    * The unique identifier of the data source.
    */
@@ -152,8 +151,7 @@ export class S3DataSource extends Construct {
 
     });
 
-    this.dataSourceId = dataSourceName;
-
+    this.dataSourceId = this.dataSource.attrDataSourceId;
   }
 }
 


### PR DESCRIPTION
As described in #470, this pull request attempts to fix the unique ID by defining the `S3DataSource.dataSource` property as `CfnDataSource` construct, and passes the created data source's unique identifier to the `S3DataSource.dataSourceId`.

Fixes #470 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.