### PR TITLE
fix(bedrock): fix default chunking strategy not deploying

### DIFF
--- a/apidocs/enums/bedrock.ChunkingStrategy.md
+++ b/apidocs/enums/bedrock.ChunkingStrategy.md
@@ -25,6 +25,8 @@ splitting them up such that each file corresponds to a chunk.
 • **DEFAULT** = ``"DEFAULT"``
 
 `FIXED_SIZE` with the default chunk size of 300 tokens and 20% overlap.
+If default is selected, chunk size and overlap set by the user will be
+ignored.
 
 ___
 

--- a/src/cdk-lib/bedrock/s3-data-source.ts
+++ b/src/cdk-lib/bedrock/s3-data-source.ts
@@ -37,6 +37,8 @@ export enum ChunkingStrategy {
   FIXED_SIZE = 'FIXED_SIZE',
   /**
    * `FIXED_SIZE` with the default chunk size of 300 tokens and 20% overlap.
+   * If default is selected, chunk size and overlap set by the user will be
+   * ignored.
    */
   DEFAULT = 'DEFAULT',
   /**
@@ -202,8 +204,16 @@ function vectorIngestionConfiguration(
       },
     };
 
-  } else {
-    return {};
+  } else { // DEFAULT
+    return {
+      chunkingConfiguration: {
+        chunkingStrategy: ChunkingStrategy.FIXED_SIZE,
+        fixedSizeChunkingConfiguration: {
+          maxTokens: CHUNKING_MAX_TOKENS,
+          overlapPercentage: CHUNKING_OVERLAP,
+        },
+      },
+    };
   }
 
 }

--- a/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
+++ b/test/cdk-lib/bedrock/__snapshots__/agent.test.ts.snap
@@ -323,7 +323,15 @@ exports[`Bedrock Agents Agent matches snapshot 1`] = `
           ],
         },
         "Name": "test-docs",
-        "VectorIngestionConfiguration": {},
+        "VectorIngestionConfiguration": {
+          "ChunkingConfiguration": {
+            "ChunkingStrategy": "FIXED_SIZE",
+            "FixedSizeChunkingConfiguration": {
+              "MaxTokens": 300,
+              "OverlapPercentage": 20,
+            },
+          },
+        },
       },
       "Type": "AWS::Bedrock::DataSource",
     },

--- a/test/cdk-lib/bedrock/s3-data-source.test.ts
+++ b/test/cdk-lib/bedrock/s3-data-source.test.ts
@@ -68,6 +68,31 @@ describe('S3 Data Source', () => {
     });
   });
 
+  test('Default chunking', () => {
+    new bedrock.S3DataSource(stack, 'TestDataSource', {
+      bucket,
+      knowledgeBase: kb,
+      dataSourceName: 'TestDataSource',
+      chunkingStrategy: bedrock.ChunkingStrategy.DEFAULT,
+      maxTokens: 1024,
+      overlapPercentage: 20,
+    });
+
+    Template.fromStack(stack).hasResourceProperties('AWS::Bedrock::DataSource', {
+
+      VectorIngestionConfiguration:
+       {
+         ChunkingConfiguration: {
+           ChunkingStrategy: 'FIXED_SIZE',
+           FixedSizeChunkingConfiguration: {
+             MaxTokens: 300,
+             OverlapPercentage: 20,
+           },
+         },
+       },
+    });
+  });
+
   test('No chunking', () => {
     new bedrock.S3DataSource(stack, 'TestDataSource', {
       bucket,


### PR DESCRIPTION
Fixes #476

- Fix non deploying data source where chunking strategy is set to DEFAULT
- Add test to cover the use case
- Updated documentation
- Tested by deploying a sample stack

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
