### PR TITLE
feat: update API documentation links in README files

### DIFF
--- a/src/cdk-lib/amazonaurora/README.md
+++ b/src/cdk-lib/amazonaurora/README.md
@@ -28,7 +28,7 @@ This construct library provides a class that defines a `AmazonAuroraVectorStore`
 
 
 ## API
-See the [API documentation](../../../apidocs/modules/amazonaurora.md).
+See the [API documentation](../../../apidocs/namespaces/amazonaurora/README.md).
 
 ## Amazon Aurora Vector Store
 

--- a/src/cdk-lib/bedrock/README.md
+++ b/src/cdk-lib/bedrock/README.md
@@ -28,7 +28,7 @@ This construct library includes CloudFormation L1 resources to deploy Bedrock fe
 - [Agents](#agents)
 
 ## API
-See the [API documentation](../../../apidocs/modules/bedrock.md).
+See the [API documentation](../../../apidocs/namespaces/bedrock/README.md).
 
 ## Knowledge Bases
 With Knowledge Bases for Amazon Bedrock, you can give FMs and agents contextual information from your company’s private data sources for Retrieval Augmented Generation (RAG) to deliver more relevant, accurate, and customized responses.

--- a/src/cdk-lib/opensearch-vectorindex/README.md
+++ b/src/cdk-lib/opensearch-vectorindex/README.md
@@ -28,7 +28,7 @@ This construct library provides a resource that creates a vector index on an Ama
 
 ## API
 
-See the [API documentation](../../../apidocs/modules/opensearchserverless.md).
+See the [API documentation](../../../apidocs/namespaces/opensearch_vectorindex/README.md).
 
 ## Vector Index
 

--- a/src/cdk-lib/opensearchserverless/README.md
+++ b/src/cdk-lib/opensearchserverless/README.md
@@ -26,7 +26,7 @@ This construct library extends the [automatically generated L1 constructs](https
 
 
 ## API
-See the [API documentation](../../../apidocs/modules/opensearchserverless.md).
+See the [API documentation](../../../apidocs/namespaces/opensearchserverless/README.md).
 
 ## Vector Collection
 This resource creates an Amazon OpenSearch Serverless collection configured for `VECTORSEARCH`. It creates default encryption, network, and data policies for use with Amazon Bedrock Knowledge Bases. For encryption, it uses the default AWS owned KMS key. It allows network connections from the public internet, but access is restricted to specific IAM principals.

--- a/src/cdk-lib/pinecone/README.md
+++ b/src/cdk-lib/pinecone/README.md
@@ -25,7 +25,7 @@ This construct library provides a class that defines an existing Pinecone databa
 - [Pinecone Vector Store](#pinecone-vector-store)
 
 ## API
-See the [API documentation](../../../apidocs/modules/pinecone.md).
+See the [API documentation](../../../apidocs/namespaces/pinecone/README.md).
 
 ## Pinecone Vector Store
 


### PR DESCRIPTION
Fixes #604 

### Incorrect
`API documentation](../../../apidocs/modules/amazonaurora.md)`

### Correct
`[API documentation](../../../apidocs/namespaces/amazonaurora/README.md)`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
