### PR TITLE
chore(projen): enable issue creation on release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
@@ -94,6 +95,19 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+      - name: Extract Version
+        id: extract-version
+        if: ${{ failure() }}
+        run: echo "VERSION=$(cat dist/version.txt)" >> $GITHUB_OUTPUT
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: gh-workflow-failing
+          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to GitHub Releases failed
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   release_npm:
     name: Publish to npm
     needs: release
@@ -101,6 +115,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      issues: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
@@ -129,12 +144,26 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+      - name: Extract Version
+        id: extract-version
+        if: ${{ failure() }}
+        run: echo "VERSION=$(cat dist/version.txt)" >> $GITHUB_OUTPUT
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: gh-workflow-failing
+          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to npm failed
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   release_pypi:
     name: Publish to PyPI
     needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
@@ -164,12 +193,26 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: npx -p publib@latest publib-pypi
+      - name: Extract Version
+        id: extract-version
+        if: ${{ failure() }}
+        run: echo "VERSION=$(cat dist/version.txt)" >> $GITHUB_OUTPUT
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: gh-workflow-failing
+          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to PyPI failed
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   release_nuget:
     name: Publish to NuGet Gallery
     needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
@@ -198,12 +241,26 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: npx -p publib@latest publib-nuget
+      - name: Extract Version
+        id: extract-version
+        if: ${{ failure() }}
+        run: echo "VERSION=$(cat dist/version.txt)" >> $GITHUB_OUTPUT
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: gh-workflow-failing
+          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to NuGet Gallery failed
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   release_golang:
     name: Publish to GitHub Go Module Repository
     needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
@@ -234,3 +291,16 @@ jobs:
           GIT_USER_EMAIL: github-actions@github.com
           GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
         run: npx -p publib@latest publib-golang
+      - name: Extract Version
+        id: extract-version
+        if: ${{ failure() }}
+        run: echo "VERSION=$(cat dist/version.txt)" >> $GITHUB_OUTPUT
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: gh-workflow-failing
+          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to GitHub Go Module Repository failed
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -130,7 +130,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
   stability: 'experimental',
   sampleCode: false,
   stale: true,
+  // To reduce the release frequency we only release features and fixes
+  // This is important because PyPI has limits on the total storage amount used, and extensions need to be manually requested
   releasableCommits: ReleasableCommits.featuresAndFixes(),
+  // If the release workflow fails for one of the package managers, we open a new GitHub issue
+  releaseFailureIssue: true,
+  releaseFailureIssueLabel: 'gh-workflow-failing',
 });
 
 // Add some useful github workflows
@@ -184,6 +189,7 @@ project.github?.actions.set('peter-evans/create-pull-request@v4', 'peter-evans/c
 project.github?.actions.set('peter-evans/create-pull-request@v5', 'peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38');
 project.github?.actions.set('peter-evans/create-pull-request@v6', 'peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50');
 project.github?.actions.set('aws-actions/configure-aws-credentials@v4.0.2', 'aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502');
+project.github?.actions.set('imjohnbo/issue-bot@v3', 'imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b');
 
 // We don't want to package certain things
 project.npmignore?.addPatterns(


### PR DESCRIPTION
Update projen configuration to create a GitHub issue if the release workflow fails

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
