### PR TITLE
chore: add missing models (3.5 sonnet and 3 opus)

### DIFF
--- a/apidocs/namespaces/bedrock/classes/BedrockFoundationModel.md
+++ b/apidocs/namespaces/bedrock/classes/BedrockFoundationModel.md
@@ -65,6 +65,12 @@ can instantiate a `BedrockFoundationModel` object, e.g: `new BedrockFoundationMo
 
 ***
 
+### ANTHROPIC\_CLAUDE\_3\_5\_SONNET\_V1\_0
+
+> `readonly` `static` **ANTHROPIC\_CLAUDE\_3\_5\_SONNET\_V1\_0**: [`BedrockFoundationModel`](BedrockFoundationModel.md)
+
+***
+
 ### ANTHROPIC\_CLAUDE\_HAIKU\_V1\_0
 
 > `readonly` `static` **ANTHROPIC\_CLAUDE\_HAIKU\_V1\_0**: [`BedrockFoundationModel`](BedrockFoundationModel.md)
@@ -74,6 +80,12 @@ can instantiate a `BedrockFoundationModel` object, e.g: `new BedrockFoundationMo
 ### ANTHROPIC\_CLAUDE\_INSTANT\_V1\_2
 
 > `readonly` `static` **ANTHROPIC\_CLAUDE\_INSTANT\_V1\_2**: [`BedrockFoundationModel`](BedrockFoundationModel.md)
+
+***
+
+### ANTHROPIC\_CLAUDE\_OPUS\_V1\_0
+
+> `readonly` `static` **ANTHROPIC\_CLAUDE\_OPUS\_V1\_0**: [`BedrockFoundationModel`](BedrockFoundationModel.md)
 
 ***
 

--- a/src/cdk-lib/bedrock/models.ts
+++ b/src/cdk-lib/bedrock/models.ts
@@ -57,6 +57,14 @@ export class BedrockFoundationModel {
     'amazon.titan-text-express-v1',
     { supportsAgents: true },
   );
+  public static readonly ANTHROPIC_CLAUDE_3_5_SONNET_V1_0 = new BedrockFoundationModel(
+    'anthropic.claude-3-5-sonnet-20240620-v1:0',
+    { supportsAgents: true },
+  );
+  public static readonly ANTHROPIC_CLAUDE_OPUS_V1_0 = new BedrockFoundationModel(
+    'anthropic.claude-3-opus-20240229-v1:0',
+    { supportsAgents: true },
+  );
   public static readonly ANTHROPIC_CLAUDE_SONNET_V1_0 = new BedrockFoundationModel(
     'anthropic.claude-3-sonnet-20240229-v1:0',
     { supportsAgents: true },


### PR DESCRIPTION
Added Opus 3 and Sonnet 3.5 to [BedrockFoundationModel](https://awslabs.github.io/generative-ai-cdk-constructs/apidocs/namespaces/bedrock/classes/BedrockFoundationModel.html).

Note that both models are supported on Agents for Bedrock: https://docs.aws.amazon.com/bedrock/latest/userguide/agents-supported.html

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
