### PR TITLE
fix: skip java build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,35 +116,6 @@ jobs:
         run: cd .repo && npx projen package:js
       - name: Collect js Artifact
         run: mv .repo/dist dist
-  package-java:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions: {}
-    if: "! needs.build.outputs.self_mutation_happened"
-    steps:
-      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
-        with:
-          distribution: corretto
-          java-version: "11"
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: 20.x
-      - name: Download build artifacts
-        uses: actions/download-artifact@b4aefff88e83a2676a730654e1ce3dce61880379
-        with:
-          name: build-artifact
-          path: dist
-      - name: Restore build artifact permissions
-        run: cd dist && setfacl --restore=permissions-backup.acl
-        continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
-      - name: Install Dependencies
-        run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create java artifact
-        run: cd .repo && npx projen package:java
-      - name: Collect java Artifact
-        run: mv .repo/dist dist
   package-python:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,6 @@ jobs:
     needs:
       - release
       - release_npm
-      - release_maven
       - release_pypi
       - release_nuget
       - release_golang
@@ -157,60 +156,6 @@ jobs:
         with:
           labels: gh-workflow-failing
           title: Publishing v${{ steps.extract-version.outputs.VERSION }} to npm failed
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  release_maven:
-    name: Publish to Maven Central
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
-    steps:
-      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
-        with:
-          distribution: corretto
-          java-version: "11"
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: 20.x
-      - name: Download build artifacts
-        uses: actions/download-artifact@b4aefff88e83a2676a730654e1ce3dce61880379
-        with:
-          name: build-artifact
-          path: dist
-      - name: Restore build artifact permissions
-        run: cd dist && setfacl --restore=permissions-backup.acl
-        continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
-      - name: Install Dependencies
-        run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create java artifact
-        run: cd .repo && npx projen package:java
-      - name: Collect java Artifact
-        run: mv .repo/dist dist
-      - name: Release
-        env:
-          MAVEN_ENDPOINT: https://s01.oss.sonatype.org
-          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
-        run: npx -p publib@latest publib-maven
-      - name: Extract Version
-        id: extract-version
-        if: ${{ failure() }}
-        run: echo "VERSION=$(cat dist/version.txt)" >> $GITHUB_OUTPUT
-      - name: Create Issue
-        if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@3daae12aa54d38685d7ff8459fc8a2aee8cea98b
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: gh-workflow-failing
-          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to Maven Central failed
           body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   release_pypi:
     name: Publish to PyPI

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,6 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
-      - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
       - status-success=package-go
@@ -28,7 +27,6 @@ pull_request_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
-      - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
       - status-success=package-go

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -324,9 +324,6 @@
           "spawn": "package:js"
         },
         {
-          "spawn": "package:java"
-        },
-        {
           "spawn": "package:python"
         },
         {
@@ -352,15 +349,6 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target go"
-        }
-      ]
-    },
-    "package:java": {
-      "name": "package:java",
-      "description": "Create java language bindings",
-      "steps": [
-        {
-          "exec": "jsii-pacmak -v --target java"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -93,12 +93,13 @@ const project = new awscdk.AwsCdkConstructLibrary({
     packageId: camelCaseIt(PUBLICATION_NAMESPACE) + '.' + camelCaseIt(PROJECT_NAME),
   },
 
-  publishToMaven: {
-    javaPackage: `io.github.${PUBLICATION_NAMESPACE.replace(/-/g, '_')}.${PROJECT_NAME.replace(/-/g, '_')}`,
-    mavenGroupId: `io.github.${PUBLICATION_NAMESPACE}`,
-    mavenArtifactId: PROJECT_NAME,
-    mavenEndpoint: 'https://s01.oss.sonatype.org',
-  },
+  //TODO: JumpStartModel.java is over 64K skipping building Java distribution until resolved.
+  // publishToMaven: {
+  //   javaPackage: `io.github.${PUBLICATION_NAMESPACE.replace(/-/g, '_')}.${PROJECT_NAME.replace(/-/g, '_')}`,
+  //   mavenGroupId: `io.github.${PUBLICATION_NAMESPACE}`,
+  //   mavenArtifactId: PROJECT_NAME,
+  //   mavenEndpoint: 'https://s01.oss.sonatype.org',
+  // },
 
   publishToGo: {
     moduleName: `github.com/${PUBLICATION_NAMESPACE}/${PROJECT_NAME}-go`,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "package-all": "npx projen package-all",
     "package:dotnet": "npx projen package:dotnet",
     "package:go": "npx projen package:go",
-    "package:java": "npx projen package:java",
     "package:js": "npx projen package:js",
     "package:python": "npx projen package:python",
     "post-compile": "npx projen post-compile",
@@ -164,13 +163,6 @@
   "jsii": {
     "outdir": "dist",
     "targets": {
-      "java": {
-        "package": "io.github.cdklabs.generative_ai_cdk_constructs",
-        "maven": {
-          "groupId": "io.github.cdklabs",
-          "artifactId": "generative-ai-cdk-constructs"
-        }
-      },
       "python": {
         "distName": "cdklabs.generative-ai-cdk-constructs",
         "module": "cdklabs.generative_ai_cdk_constructs"


### PR DESCRIPTION
This pull request removes packaging and distributing java, because the `JumpStartModel.java` file exceeds the 64K maximum size.

https://github.com/awslabs/generative-ai-cdk-constructs/actions/runs/11861384594/job/33058880785?pr=800

> code too large

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
