### PR TITLE
feat(cw): update bedrock cloudwatch dashboard

### DIFF
--- a/apidocs/classes/BedrockCwDashboard.md
+++ b/apidocs/classes/BedrockCwDashboard.md
@@ -30,7 +30,7 @@ represents the scope for all the resources.
 
 this is a a scope-unique id.
 
-• **props**: [`BedrockCwDashboardProps`](../interfaces/BedrockCwDashboardProps.md)
+• **props**: [`BedrockCwDashboardProps`](../interfaces/BedrockCwDashboardProps.md) = `{}`
 
 user provided props for the construct.
 

--- a/apidocs/classes/BedrockCwDashboard.md
+++ b/apidocs/classes/BedrockCwDashboard.md
@@ -74,7 +74,7 @@ The tree node.
 
 #### Parameters
 
-• **props**: [`ModelMonitoringProps`](../interfaces/ModelMonitoringProps.md)
+• **props**: [`ModelMonitoringProps`](../interfaces/ModelMonitoringProps.md) = `{}`
 
 #### Returns
 
@@ -92,7 +92,7 @@ The tree node.
 
 • **modelId**: `string`
 
-• **props**: [`ModelMonitoringProps`](../interfaces/ModelMonitoringProps.md)
+• **props**: [`ModelMonitoringProps`](../interfaces/ModelMonitoringProps.md) = `{}`
 
 #### Returns
 

--- a/apidocs/interfaces/ModelMonitoringProps.md
+++ b/apidocs/interfaces/ModelMonitoringProps.md
@@ -22,6 +22,18 @@ The properties for the ModelMonitoringProps class.
 
 ***
 
+### inputTokenPrice?
+
+> `readonly` `optional` **inputTokenPrice**: `number`
+
+***
+
+### outputTokenPrice?
+
+> `readonly` `optional` **outputTokenPrice**: `number`
+
+***
+
 ### period?
 
 > `readonly` `optional` **period**: `Duration`

--- a/apidocs/interfaces/ModelMonitoringProps.md
+++ b/apidocs/interfaces/ModelMonitoringProps.md
@@ -10,6 +10,18 @@ The properties for the ModelMonitoringProps class.
 
 ## Properties
 
+### bucketedStepSize?
+
+> `readonly` `optional` **bucketedStepSize**: `string`
+
+***
+
+### imageSize?
+
+> `readonly` `optional` **imageSize**: `string`
+
+***
+
 ### period?
 
 > `readonly` `optional` **period**: `Duration`

--- a/src/patterns/gen-ai/aws-bedrock-cw-dashboard/README.md
+++ b/src/patterns/gen-ai/aws-bedrock-cw-dashboard/README.md
@@ -44,7 +44,13 @@ Thanks to @jimini55, @scoropeza, @PaulVincent707, @Ishanrpatel, @lowelljehu and 
 
 This construct provides an Amazon CloudWatch dashboard to monitor metrics on Amazon Bedrock models usage. The specific list of metrics created by this construct is available [here](#default-properties).
 
-> **Note:** Native metrics for Amazon Bedrock don't support dimensions beyond model ID. If a single account is hosting multiple workloads in the same region, the Bedrock metrics would be aggregated across all workloads.
+These metrics can be used for a variety of use cases including:
+
+- Comparing latency between different models using the InvocationLatency metric with ModelId dimension
+- Measuring token count (input & output) to assist in purchasing provisioned throughput by analyzing the InputTokenCount and OutputTokenCount
+- Detecting and alerting on throttling with an CloudWatch Alarm with the InvocationThrottles metric
+
+> **Note:** Native runtime metrics for Amazon Bedrock don't support dimensions beyond model ID. If a single account is hosting multiple workloads in the same region, the Bedrock metrics would be aggregated across all workloads.
 
 Here is a minimal deployable pattern definition:
 
@@ -55,13 +61,13 @@ import { Construct } from 'constructs';
 import { Stack, StackProps, Aws } from 'aws-cdk-lib';
 import { BedrockCwDashboard } from '@cdklabs/generative-ai-cdk-constructs';
 
-const bddashboard = new BedrockCwDashboard(this, 'BedrockDashboardConstruct', {});
+const bddashboard = new BedrockCwDashboard(this, 'BedrockDashboardConstruct');
 
 // provides monitoring for a specific model
-bddashboard.addModelMonitoring('claude3haiku', 'anthropic.claude-3-haiku-20240307-v1:0', {});
+bddashboard.addModelMonitoring('claude3haiku', 'anthropic.claude-3-haiku-20240307-v1:0');
 
 // provides monitoring of all models
-bddashboard.addAllModelsMonitoring({});
+bddashboard.addAllModelsMonitoring();
 ```
 
 Optionally, you can also use the [Bedrock models](../../../cdk-lib/bedrock/models.ts) to access the modelId:
@@ -75,8 +81,7 @@ import { bedrock, BedrockCwDashboard } from '@cdklabs/generative-ai-cdk-construc
 // provides monitoring for a specific model
 bddashboard.addModelMonitoring(
     'claude3haiku', 
-    bedrock.BedrockFoundationModel.ANTHROPIC_CLAUDE_HAIKU_V1_0.modelId, 
-    {}
+    bedrock.BedrockFoundationModel.ANTHROPIC_CLAUDE_HAIKU_V1_0.modelId
 );
 
 ...
@@ -132,7 +137,7 @@ Parameters
 
 ### addModelMonitoring()
 
-Provide metrics for a specific model id in Bedrock
+Provide runtime metrics for a specific model id in Bedrock.
 
 @param {string} modelName - Model name as it will appear in the dashboard row widget.
 
@@ -142,7 +147,7 @@ Provide metrics for a specific model id in Bedrock
 
 ### addAllModelsMonitoring()
 
-Add a new row to the dashboard providing metrics across all model ids in Bedrock 
+Add a new row to the dashboard providing runtime metrics across all model ids in Bedrock. 
 
 @param {ModelMonitoringProps} props - user provided props for the monitoring.
 
@@ -160,9 +165,15 @@ Out-of-the-box implementation of the construct without any override will set the
 - The following metrics are displayed for the model specified:
     - InputTokenCount
     - OutputTokenCount
+    - OutputImageCount
     - InvocationLatency (min, max, average)
     - Invocations (sample count)
     - InvocationClientErrors
+    - InvocationServerErrors
+    - InvocationThrottles
+    - LegacyModelInvocations
+
+More details for each one of the metrics can be found in the [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring.html#runtime-cloudwatch-metrics)
 
 ### addAllModelsMonitoring
 
@@ -173,6 +184,11 @@ Out-of-the-box implementation of the construct without any override will set the
     - InvocationLatency (min, max, average)
     - Invocations (sample count)
     - InvocationClientErrors
+    - InvocationServerErrors
+    - InvocationThrottles
+    - LegacyModelInvocations
+
+More details for each one of the metrics can be found in the [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring.html#runtime-cloudwatch-metrics)
 
 ## Cost
 

--- a/src/patterns/gen-ai/aws-bedrock-cw-dashboard/README.md
+++ b/src/patterns/gen-ai/aws-bedrock-cw-dashboard/README.md
@@ -50,6 +50,8 @@ These metrics can be used for a variety of use cases including:
 - Measuring token count (input & output) to assist in purchasing provisioned throughput by analyzing the InputTokenCount and OutputTokenCount
 - Detecting and alerting on throttling with an CloudWatch Alarm with the InvocationThrottles metric
 
+For a specific model, if input/output tokens cost is specified, a widget with on-demand input and total tokens cost will be added. Please refer to the [Amazon Bedrock Pricing page](https://aws.amazon.com/bedrock/pricing/) for details about pricing.
+
 > **Note:** Native runtime metrics for Amazon Bedrock don't support dimensions beyond model ID. If a single account is hosting multiple workloads in the same region, the Bedrock metrics would be aggregated across all workloads.
 
 Here is a minimal deployable pattern definition:
@@ -65,6 +67,13 @@ const bddashboard = new BedrockCwDashboard(this, 'BedrockDashboardConstruct');
 
 // provides monitoring for a specific model
 bddashboard.addModelMonitoring('claude3haiku', 'anthropic.claude-3-haiku-20240307-v1:0');
+
+// provides monitoring for a specific model with on-demand pricing calculation
+// pricing details are available here: https://aws.amazon.com/bedrock/pricing/
+bddashboard.addModelMonitoring('claude3haiku', 'anthropic.claude-3-haiku-20240307-v1:0', {
+    inputTokenPrice: 0.00025,
+    outputTokenPrice: 0.00125
+});
 
 // provides monitoring of all models
 bddashboard.addAllModelsMonitoring();
@@ -102,6 +111,15 @@ bddashboard.add_model_monitoring(
     model_id: 'anthropic.claude-3-haiku-20240307-v1:0'
 )
 
+# provides monitoring for a specific model with on-demand pricing calculation
+# pricing details are available here: https://aws.amazon.com/bedrock/pricing/
+bddashboard.add_model_monitoring(
+    model_name: 'claude3haiku',
+    model_id: 'anthropic.claude-3-haiku-20240307-v1:0',
+    input_token_price: 0.00025,
+    output_token_price: 0.00125
+)
+
 # provides monitoring of all models
 bddashboard.add_all_models_monitoring()
 ```
@@ -137,7 +155,7 @@ Parameters
 
 ### addModelMonitoring()
 
-Provide runtime metrics for a specific model id in Bedrock.
+Provide runtime metrics for a specific model id in Bedrock. If input/output tokens cost is specified, a widget with on-demand input and total tokens cost will be added.
 
 @param {string} modelName - Model name as it will appear in the dashboard row widget.
 
@@ -158,6 +176,7 @@ Out-of-the-box implementation of the construct without any override will set the
 ### Dashboard
 
 - Dashboard name is ```BedrockMetricsDashboard```
+- CfnOutput containing the created CloudWatch dashboard URL
 
 ### addModelMonitoring
 
@@ -172,6 +191,10 @@ Out-of-the-box implementation of the construct without any override will set the
     - InvocationServerErrors
     - InvocationThrottles
     - LegacyModelInvocations
+If pricing is specified, a new widget will be added with the following metrics:
+    - Input Token Cost
+    - Output Token Cost
+    - Total Token Cost
 
 More details for each one of the metrics can be found in the [documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring.html#runtime-cloudwatch-metrics)
 
@@ -197,6 +220,7 @@ You are responsible for the cost of the AWS services used while running this con
 We recommend creating a budget through [AWS Cost Explorer](http://aws.amazon.com/aws-cost-management/aws-cost-explorer/) to help manage costs. Prices are subject to change. For full details, refer to the pricing webpage for each AWS service used in this solution:
 
 - [Amazon CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/)
+- [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/)
 
 ## Security
 

--- a/src/patterns/gen-ai/aws-bedrock-cw-dashboard/index.ts
+++ b/src/patterns/gen-ai/aws-bedrock-cw-dashboard/index.ts
@@ -311,6 +311,7 @@ export class BedrockCwDashboard extends Construct {
               showUnits: false,
             },
             width: 12,
+            height: 10,
           });
     }
 

--- a/src/patterns/gen-ai/aws-bedrock-cw-dashboard/index.ts
+++ b/src/patterns/gen-ai/aws-bedrock-cw-dashboard/index.ts
@@ -19,7 +19,6 @@ import {
   Row,
   Stats,
   TextWidget,
-  Column,
 } from 'aws-cdk-lib/aws-cloudwatch';
 import { Construct } from 'constructs';
 
@@ -256,45 +255,35 @@ export class BedrockCwDashboard extends Construct {
           width: 12,
           height: 10,
         }),
-      ),
-    );
-
-    this.dashboard.addWidgets(
-      new Row(
-        new SingleValueWidget({
-          title: 'OutputImageCount',
-          metrics: [modelOutputImageMetric],
-          width: 12,
-        }),
-      ),
-    );
-
-    this.dashboard.addWidgets(
-      new Row(
         new SingleValueWidget({
           title: 'Invocations',
           metrics: [modelInvocationsCountMetric],
-          width: 12,
+          width: 4,
         }),
         new SingleValueWidget({
           title: 'Client Errors',
           metrics: [modelInvocationsClientErrorsMetric],
-          width: 12,
+          width: 4,
         }),
         new SingleValueWidget({
           title: 'Server Errors',
           metrics: [modelInvocationsServerErrorsMetric],
-          width: 12,
+          width: 4,
         }),
         new SingleValueWidget({
           title: 'Throttled invocations',
           metrics: [modelInvocationsThrottlesErrorsMetric],
-          width: 12,
+          width: 4,
         }),
         new SingleValueWidget({
           title: 'Legacy invocations',
           metrics: [modelInvocationsLegacysMetric],
-          width: 12,
+          width: 4,
+        }),
+        new SingleValueWidget({
+          title: 'OutputImageCount',
+          metrics: [modelOutputImageMetric],
+          width: 4,
         }),
       ),
     );
@@ -414,59 +403,43 @@ export class BedrockCwDashboard extends Construct {
     );
     this.dashboard.addWidgets(
       new Row(
-        new Column(
-          new Row(
-            new GraphWidget({
-              title: 'Input and Output Tokens (All Models)',
-              left: [inputTokensAllModelsMetric],
-              right: [outputTokensAllModelsMetric],
-              period: period,
-              width: 12,
-            }),
-            new SingleValueWidget({
-              title: 'Output Image Count (All Models)',
-              metrics: [outputImageMetric],
-              width: 12,
-            }),
-          ),
-        ),
-        new Column(
-          new Row(
-            new SingleValueWidget({
-              title: 'Invocations (All Models)',
-              metrics: [invocationsCountAllModelsMetric],
-              width: 12,
-            }),
-          ),
-          new Row(
-            new SingleValueWidget({
-              title: 'Client Errors (All Models)',
-              metrics: [invocationsClientErrorsAllModelsMetric],
-              width: 12,
-            }),
-          ),
-          new Row(
-            new SingleValueWidget({
-              title: 'Server Errors (All Models)',
-              metrics: [invocationsServerErrorsAllModelsMetric],
-              width: 12,
-            }),
-          ),
-          new Row(
-            new SingleValueWidget({
-              title: 'Throttling Errors (All Models)',
-              metrics: [invocationsThrottlesErrorsMetric],
-              width: 12,
-            }),
-          ),
-          new Row(
-            new SingleValueWidget({
-              title: 'Legacy invocations (All Models)',
-              metrics: [invocationsLegacyModelMetric],
-              width: 12,
-            }),
-          ),
-        ),
+        new GraphWidget({
+          title: 'Input and Output Tokens (All Models)',
+          left: [inputTokensAllModelsMetric],
+          right: [outputTokensAllModelsMetric],
+          period: period,
+          width: 12,
+        }),
+        new SingleValueWidget({
+          title: 'Invocations (All Models)',
+          metrics: [invocationsCountAllModelsMetric],
+          width: 4,
+        }),
+        new SingleValueWidget({
+          title: 'Output Image Count (All Models)',
+          metrics: [outputImageMetric],
+          width: 4,
+        }),
+        new SingleValueWidget({
+          title: 'Client Errors (All Models)',
+          metrics: [invocationsClientErrorsAllModelsMetric],
+          width: 4,
+        }),
+        new SingleValueWidget({
+          title: 'Server Errors (All Models)',
+          metrics: [invocationsServerErrorsAllModelsMetric],
+          width: 4,
+        }),
+        new SingleValueWidget({
+          title: 'Throttling Errors (All Models)',
+          metrics: [invocationsThrottlesErrorsMetric],
+          width: 4,
+        }),
+        new SingleValueWidget({
+          title: 'Legacy invocations (All Models)',
+          metrics: [invocationsLegacyModelMetric],
+          width: 4,
+        }),
       ),
     );
   }


### PR DESCRIPTION
Fixes #

Thanks @jimini55 for the pricing widget !

Update the bedrock CloudWatch dashboard to add the following:
- Missing runtime metrics added recently
- Add default ```= {}``` to props to avoid providing empty brackets if props not provided by user
- Create a CfnOutput with as value the URL of the created cloudwatch dashboard
- Pricing widget for a model if input/output pricing is provided by the user
- Update documentation

Tests:

<img width="1895" alt="Screenshot 2024-11-29 at 11 23 56 AM" src="https://github.com/user-attachments/assets/e5c832f0-5a9a-4da9-843e-108e11576097">

<img width="1898" alt="image" src="https://github.com/user-attachments/assets/74b9ee25-9a62-4cbd-8ff7-822883461a65">

Also tested to generate 2 dashboards in the same stack to make sure there is no collision in naming/id

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
