### PR TITLE
feat(bedrock): add support in agents for nova models

### DIFF
--- a/apidocs/namespaces/bedrock/classes/BedrockFoundationModel.md
+++ b/apidocs/namespaces/bedrock/classes/BedrockFoundationModel.md
@@ -89,6 +89,24 @@ The ARN of the Bedrock invokable abstraction.
 
 ***
 
+### AMAZON\_NOVA\_LITE\_V1
+
+> `readonly` `static` **AMAZON\_NOVA\_LITE\_V1**: [`BedrockFoundationModel`](BedrockFoundationModel.md)
+
+***
+
+### AMAZON\_NOVA\_MICRO\_V1
+
+> `readonly` `static` **AMAZON\_NOVA\_MICRO\_V1**: [`BedrockFoundationModel`](BedrockFoundationModel.md)
+
+***
+
+### AMAZON\_NOVA\_PRO\_V1
+
+> `readonly` `static` **AMAZON\_NOVA\_PRO\_V1**: [`BedrockFoundationModel`](BedrockFoundationModel.md)
+
+***
+
 ### AMAZON\_TITAN\_PREMIER\_V1\_0
 
 > `readonly` `static` **AMAZON\_TITAN\_PREMIER\_V1\_0**: [`BedrockFoundationModel`](BedrockFoundationModel.md)

--- a/src/cdk-lib/bedrock/models.ts
+++ b/src/cdk-lib/bedrock/models.ts
@@ -76,6 +76,18 @@ export class BedrockFoundationModel implements IInvokable {
     supportsAgents: true,
   });
 
+  public static readonly AMAZON_NOVA_MICRO_V1 = new BedrockFoundationModel('amazon.nova-micro-v1:0', {
+    supportsAgents: true,
+  });
+
+  public static readonly AMAZON_NOVA_LITE_V1 = new BedrockFoundationModel('amazon.nova-lite-v1:0', {
+    supportsAgents: true,
+  });
+
+  public static readonly AMAZON_NOVA_PRO_V1 = new BedrockFoundationModel('amazon.nova-pro-v1:0', {
+    supportsAgents: true,
+  });
+
   public static readonly TITAN_EMBED_TEXT_V1 = new BedrockFoundationModel('amazon.titan-embed-text-v1', {
     supportsKnowledgeBase: true,
     vectorDimensions: 1536,


### PR DESCRIPTION
Fixes #834

Add support for https://aws.amazon.com/about-aws/whats-new/2024/12/amazon-nova-foundation-models-bedrock/
Tested by creating 3 agents (one with each model)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
