### PR TITLE
Revert "chore(deps-dev): bump the dev-dependencies group with 6 updates"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,17 +37,17 @@
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jest-junit": "^15",
-        "jsii": "~5.4.46",
+        "jsii": "~5.4.0",
         "jsii-diff": "^1.106.0",
         "jsii-pacmak": "^1.106.0",
-        "jsii-rosetta": "~5.4.46",
+        "jsii-rosetta": "~5.4.0",
         "pinst": "^3.0.0",
         "projen": "~0.84.5",
         "standard-version": "^9",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typedoc": "^0.27.6",
-        "typedoc-plugin-markdown": "^4.3.3",
+        "typedoc": "^0.27.5",
+        "typedoc-plugin-markdown": "^4.3.2",
         "typescript": "^5.7.2"
       },
       "engines": {
@@ -1959,10 +1959,11 @@
       }
     },
     "node_modules/@jsii/check-node": {
-      "version": "1.106.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.106.0.tgz",
-      "integrity": "sha512-/T/TUsbHdEbZRFR4Rem9+UXVvgMYncEkrIeC52oIHJ8BDSgqlDsIARio/Eu5DOftF4avSLV/sshR6n19mpK1oA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.103.1.tgz",
+      "integrity": "sha512-Vi6ONm5WXEim98a2DJ6WMlrP/w5AGzXrrQBpGcfVV7cu86DPx1L0OAZnqzGAJE8ly0VfcSXkmxJ9LFcn3jylBQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
         "semver": "^7.6.3"
@@ -2295,10 +2296,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.68.tgz",
-      "integrity": "sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==",
+      "version": "18.19.54",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2557,10 +2557,9 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.6.tgz",
-      "integrity": "sha512-Su4xcxR0CPGwlDHNmVP09fqET9YxbyDXHaSob6JlBH7L6reTYaeim6zbk9o08UarO0L5GTRo3uzl0D+9lSxmvw==",
+      "version": "0.9.3",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.6"
       }
@@ -2897,10 +2896,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.173.4",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.4.tgz",
-      "integrity": "sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==",
+      "version": "2.161.1",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -7823,13 +7821,13 @@
       }
     },
     "node_modules/jsii": {
-      "version": "5.4.47",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.4.47.tgz",
-      "integrity": "sha512-CKRmygq+crvzLPijY71MFzTacbBd4OKqeaj44CtODQBvWpP6k4KH6IWkJQkroZSGXpERfwLDyTeed950p3cZkg==",
+      "version": "5.4.46",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.4.46.tgz",
+      "integrity": "sha512-itwNZbWV9AaV5o+OScCv94C2uFmC9RlrVpvnMmW+R6N3Js4SjklVApunpQp8YRhMoehMWKqInz3RXcahdL1VEA==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.106.0",
-        "@jsii/spec": "^1.106.0",
+        "@jsii/check-node": "1.105.0",
+        "@jsii/spec": "^1.105.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "downlevel-dts": "^0.11.0",
@@ -7869,6 +7867,19 @@
         "node": ">= 14.17.0"
       }
     },
+    "node_modules/jsii-diff/node_modules/@jsii/check-node": {
+      "version": "1.106.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.106.0.tgz",
+      "integrity": "sha512-/T/TUsbHdEbZRFR4Rem9+UXVvgMYncEkrIeC52oIHJ8BDSgqlDsIARio/Eu5DOftF4avSLV/sshR6n19mpK1oA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
     "node_modules/jsii-pacmak": {
       "version": "1.106.0",
       "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.106.0.tgz",
@@ -7896,6 +7907,19 @@
       },
       "peerDependencies": {
         "jsii-rosetta": ">=5.4.0"
+      }
+    },
+    "node_modules/jsii-pacmak/node_modules/@jsii/check-node": {
+      "version": "1.106.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.106.0.tgz",
+      "integrity": "sha512-/T/TUsbHdEbZRFR4Rem9+UXVvgMYncEkrIeC52oIHJ8BDSgqlDsIARio/Eu5DOftF4avSLV/sshR6n19mpK1oA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/jsii-pacmak/node_modules/escape-string-regexp": {
@@ -7931,22 +7955,36 @@
         "node": ">= 14.17.0"
       }
     },
-    "node_modules/jsii-rosetta": {
-      "version": "5.4.51",
-      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.4.51.tgz",
-      "integrity": "sha512-XxVR0Hqlhvabza9Z5M4LWhfhmHldaxaLKDkaS81541RuxpFgjMITkPxQD4bLzAvG/0T4wfr5EGeJSeK25cFvPQ==",
+    "node_modules/jsii-reflect/node_modules/@jsii/check-node": {
+      "version": "1.106.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.106.0.tgz",
+      "integrity": "sha512-/T/TUsbHdEbZRFR4Rem9+UXVvgMYncEkrIeC52oIHJ8BDSgqlDsIARio/Eu5DOftF4avSLV/sshR6n19mpK1oA==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.106.0",
-        "@jsii/spec": "^1.106.0",
-        "@xmldom/xmldom": "^0.9.6",
+        "chalk": "^4.1.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/jsii-rosetta": {
+      "version": "5.4.36",
+      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.4.36.tgz",
+      "integrity": "sha512-7rYdbq0NCTID6XSxJYZkMLfrO+8loO2ZSlokVLgAeEQ1YSwF6ydqLHuFkYr4iZwpugLSSLVDRi8q+e6aHh9XBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsii/check-node": "1.103.1",
+        "@jsii/spec": "^1.103.1",
+        "@xmldom/xmldom": "^0.9.0",
         "chalk": "^4",
-        "commonmark": "^0.31.2",
+        "commonmark": "^0.31.1",
         "fast-glob": "^3.3.2",
         "jsii": "~5.4.0",
         "semver": "^7.6.3",
         "semver-intersect": "^1.5.0",
-        "stream-json": "^1.9.1",
+        "stream-json": "^1.8.0",
         "typescript": "~5.4",
         "workerpool": "^6.5.1",
         "yargs": "^17.7.2"
@@ -8014,6 +8052,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/jsii/node_modules/@jsii/check-node": {
+      "version": "1.105.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.105.0.tgz",
+      "integrity": "sha512-7QIzioc9//TwRjLhGMllcTBfIvJ0h6OeGVUEYdXB1DpCNtMbr8Xcj5KaeKHRAF9iRjB1d0IGzKm4A8fRUzIf+Q==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/jsii/node_modules/cliui": {
@@ -11027,13 +11078,15 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
       "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/stream-json": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
-      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.8.0.tgz",
+      "integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
@@ -11720,9 +11773,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
-      "integrity": "sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.5.tgz",
+      "integrity": "sha512-x+fhKJtTg4ozXwKayh/ek4wxZQI/+2hmZUdO2i2NGDBRUflDble70z+ewHod3d4gRpXSO6fnlnjbDTnJk7HlkQ==",
       "dev": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^1.24.0",
@@ -11742,9 +11795,9 @@
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.3.3.tgz",
-      "integrity": "sha512-kESCcNRzOcFJATLML2FoCfaTF9c0ujmbZ+UXsJvmNlFLS3v8tDKfDifreJXvXWa9d8gUcetZqOqFcZ/7+Ba34Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.3.2.tgz",
+      "integrity": "sha512-hCF3V0axzbzGDYFW21XigWIJQBOJ2ZRVWWs7X+e62ew/pXnvz7iKF/zVdkBm3w8Mk4bmXWp/FT0IF4Zn9uBRww==",
       "dev": true,
       "engines": {
         "node": ">= 18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,6 +816,14 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsii/check-node@1.105.0":
+  version "1.105.0"
+  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.105.0.tgz#92ffea17d1497ddf9b104088d65a363bbf9d2b64"
+  integrity sha512-7QIzioc9//TwRjLhGMllcTBfIvJ0h6OeGVUEYdXB1DpCNtMbr8Xcj5KaeKHRAF9iRjB1d0IGzKm4A8fRUzIf+Q==
+  dependencies:
+    chalk "^4.1.2"
+    semver "^7.6.3"
+
 "@jsii/check-node@1.106.0":
   version "1.106.0"
   resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.106.0.tgz#5deb20b0bbe0a506c4bd9edf60b17b0a93f83834"
@@ -824,7 +832,7 @@
     chalk "^4.1.2"
     semver "^7.6.3"
 
-"@jsii/spec@^1.103.1", "@jsii/spec@^1.106.0":
+"@jsii/spec@^1.103.1", "@jsii/spec@^1.105.0", "@jsii/spec@^1.106.0":
   version "1.106.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.106.0.tgz#f40010ec8cde14b7a003dd5b6a46480d9d7e222f"
   integrity sha512-pAIvqEGf0YLmtzFtUKWNEGkCmXMHENy7k+rzCD147wnM4jHhvEL1mEvxi99aA2VcmvLYaAYNOs/XozT+s+kLqQ==
@@ -3967,12 +3975,12 @@ jsii-rosetta@~5.4.46:
     yargs "^17.7.2"
 
 jsii@~5.4.0, jsii@~5.4.46:
-  version "5.4.47"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.4.47.tgz#e6348e0c1b265d7ca7d852287840ebb0f77d8f7a"
-  integrity sha512-CKRmygq+crvzLPijY71MFzTacbBd4OKqeaj44CtODQBvWpP6k4KH6IWkJQkroZSGXpERfwLDyTeed950p3cZkg==
+  version "5.4.46"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.4.46.tgz#9f2619a06abee0539fdc0293cd90409fed580131"
+  integrity sha512-itwNZbWV9AaV5o+OScCv94C2uFmC9RlrVpvnMmW+R6N3Js4SjklVApunpQp8YRhMoehMWKqInz3RXcahdL1VEA==
   dependencies:
-    "@jsii/check-node" "1.106.0"
-    "@jsii/spec" "^1.106.0"
+    "@jsii/check-node" "1.105.0"
+    "@jsii/spec" "^1.105.0"
     case "^1.6.3"
     chalk "^4"
     downlevel-dts "^0.11.0"


### PR DESCRIPTION
Reverts awslabs/generative-ai-cdk-constructs#863

This is managed by Projen and will cause issues if merged as is
Sorry the auto generated PR should not be created by Dependabot