### PR TITLE
chore(deps): add dependency to resource for CRIS

### DIFF
--- a/src/cdk-lib/bedrock/agents/agent.ts
+++ b/src/cdk-lib/bedrock/agents/agent.ts
@@ -378,8 +378,6 @@ export class Agent extends AgentBase {
           },
         }),
       });
-      // add the appropriate permissions to use the FM
-      this.foundationModel.grantInvoke(this.role);
     }
     // ------------------------------------------------------
     // Set Lazy Props initial values
@@ -441,7 +439,9 @@ export class Agent extends AgentBase {
     // Add explicit dependency between the agent resource and the agent's role default policy
     // See https://github.com/awslabs/generative-ai-cdk-constructs/issues/899
     if (!props.existingRole) {
-      this.__resource.node.addDependency(this.role.node.findChild('DefaultPolicy'));
+      // add the appropriate permissions to use the FM
+      const grant = this.foundationModel.grantInvoke(this.role);
+      grant.applyBefore(this.__resource);
     }
 
     this.testAlias = AgentAlias.fromAttributes(this, 'DefaultAlias', {

--- a/src/cdk-lib/bedrock/agents/agent.ts
+++ b/src/cdk-lib/bedrock/agents/agent.ts
@@ -437,6 +437,13 @@ export class Agent extends AgentBase {
     this.agentArn = this.__resource.attrAgentArn;
     this.agentVersion = this.__resource.attrAgentVersion;
     this.lastUpdated = this.__resource.attrUpdatedAt;
+
+    // Add explicit dependency between the agent resource and the agent's role default policy
+    // See https://github.com/awslabs/generative-ai-cdk-constructs/issues/899
+    if (!props.existingRole) {
+      this.__resource.node.addDependency(this.role.node.findChild('DefaultPolicy'));
+    }
+
     this.testAlias = AgentAlias.fromAttributes(this, 'DefaultAlias', {
       aliasId: 'TSTALIASID',
       aliasName: 'AgentTestAlias',

--- a/test/integ/inference-profiles.integ.snapshot/aws-cdk-bedrock-guardrails-integ-test.assets.json
+++ b/test/integ/inference-profiles.integ.snapshot/aws-cdk-bedrock-guardrails-integ-test.assets.json
@@ -1,7 +1,7 @@
 {
   "version": "39.0.0",
   "files": {
-    "8371c500cdb7d7db47b783ce965da719cc175fa62f9299c41a60f868691dbe0a": {
+    "fc1142f404eb5443446b22592dc6d75ae8c80055bfb9474da78f4254ae394a4f": {
       "source": {
         "path": "aws-cdk-bedrock-guardrails-integ-test.template.json",
         "packaging": "file"
@@ -9,7 +9,7 @@
       "destinations": {
         "current_account-eu-central-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-central-1",
-          "objectKey": "8371c500cdb7d7db47b783ce965da719cc175fa62f9299c41a60f868691dbe0a.json",
+          "objectKey": "fc1142f404eb5443446b22592dc6d75ae8c80055bfb9474da78f4254ae394a4f.json",
           "region": "eu-central-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-eu-central-1"
         }

--- a/test/integ/inference-profiles.integ.snapshot/aws-cdk-bedrock-guardrails-integ-test.template.json
+++ b/test/integ/inference-profiles.integ.snapshot/aws-cdk-bedrock-guardrails-integ-test.template.json
@@ -124,7 +124,10 @@
     "IdleSessionTTLInSeconds": 3600,
     "Instruction": "You are a test bot that needs to be very gentle and useful to the user",
     "SkipResourceInUseCheckOnDelete": false
-   }
+   },
+   "DependsOn": [
+    "TestAgentsimpleRoleDefaultPolicy585202B2"
+   ]
   },
   "TestAgentcrisRole15797E3B": {
    "Type": "AWS::IAM::Role",
@@ -277,7 +280,10 @@
     "IdleSessionTTLInSeconds": 3600,
     "Instruction": "You are a test bot that needs to be very gentle and useful to the user",
     "SkipResourceInUseCheckOnDelete": false
-   }
+   },
+   "DependsOn": [
+    "TestAgentcrisRoleDefaultPolicy6C083E13"
+   ]
   },
   "TestAppProfile97C615D8": {
    "Type": "AWS::Bedrock::ApplicationInferenceProfile",
@@ -463,7 +469,10 @@
     "IdleSessionTTLInSeconds": 3600,
     "Instruction": "You are a test bot that needs to be very gentle and useful to the user",
     "SkipResourceInUseCheckOnDelete": false
-   }
+   },
+   "DependsOn": [
+    "TestAgentaipRoleDefaultPolicyD4F0F0D5"
+   ]
   }
  },
  "Parameters": {

--- a/test/integ/issue747.integ.snapshot/aws-cdk-bedrock-agents-integ-test.assets.json
+++ b/test/integ/issue747.integ.snapshot/aws-cdk-bedrock-agents-integ-test.assets.json
@@ -1,7 +1,7 @@
 {
   "version": "39.0.0",
   "files": {
-    "af068d207758560bdaa77dd8cf7bc3626034f1d007a7d014cb51363863752caa": {
+    "edce2cdca448655b4baa3a3f25397547640d54472ced24d6b7c09954e1b4a72c": {
       "source": {
         "path": "aws-cdk-bedrock-agents-integ-test.template.json",
         "packaging": "file"
@@ -9,7 +9,7 @@
       "destinations": {
         "current_account-eu-central-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-central-1",
-          "objectKey": "af068d207758560bdaa77dd8cf7bc3626034f1d007a7d014cb51363863752caa.json",
+          "objectKey": "edce2cdca448655b4baa3a3f25397547640d54472ced24d6b7c09954e1b4a72c.json",
           "region": "eu-central-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-eu-central-1"
         }

--- a/test/integ/issue747.integ.snapshot/aws-cdk-bedrock-agents-integ-test.template.json
+++ b/test/integ/issue747.integ.snapshot/aws-cdk-bedrock-agents-integ-test.template.json
@@ -166,7 +166,10 @@
     "IdleSessionTTLInSeconds": 3600,
     "Instruction": "You are a helpful and friendly agent that answers questions about literature.",
     "SkipResourceInUseCheckOnDelete": false
-   }
+   },
+   "DependsOn": [
+    "AgentRoleDefaultPolicyA34CCA36"
+   ]
   },
   "Agent2Role38FC3F9C": {
    "Type": "AWS::IAM::Role",
@@ -334,7 +337,10 @@
     "IdleSessionTTLInSeconds": 3600,
     "Instruction": "You are a helpful and friendly agent that answers questions about unicorns.",
     "SkipResourceInUseCheckOnDelete": false
-   }
+   },
+   "DependsOn": [
+    "Agent2RoleDefaultPolicy55328F4A"
+   ]
   },
   "ActionGroupFunctionServiceRole77660D62": {
    "Type": "AWS::IAM::Role",


### PR DESCRIPTION
Fixes #899 

Thanks to @mccauleyp for the investigation. Fixes the issue where some CRIS models cannot be used as there is a missing dependency.

Test:

```
const cris = bedrock.CrossRegionInferenceProfile.fromConfig({
      geoRegion: bedrock.CrossRegionInferenceProfileRegion.US,
      model: bedrock.BedrockFoundationModel.ANTHROPIC_CLAUDE_3_5_SONNET_V2_0,
    });
    
    const agent = new bedrock.Agent(this, 'Agent', {
      foundationModel: cris,
      instruction: 'You are a helpful and friendly agent that answers questions about agriculture.',
    });
```

(Also tested with ***ANTHROPIC_CLAUDE_3_5_HAIKU_V1_0*** and ***ANTHROPIC_CLAUDE_3_5_SONNET_V1_0***)

Deployment succeeds: 

<img width="788" alt="Screenshot 2025-01-23 at 12 34 23 PM" src="https://github.com/user-attachments/assets/59cdab86-e36b-4725-8494-0fa259b6bf3f" />

The correct model is used in the console:

![Screenshot 2025-01-23 at 12 34 15 PM](https://github.com/user-attachments/assets/5d584242-9f9d-44fe-b696-b8f225b2908f)

The agent is able to perform requests against the model:

![Screenshot 2025-01-23 at 12 34 02 PM](https://github.com/user-attachments/assets/ca32aa14-6bcc-4aab-abaf-22c55999d401)

The stack is destroyed correctly:

<img width="362" alt="Screenshot 2025-01-23 at 12 39 21 PM" src="https://github.com/user-attachments/assets/584dbd10-845d-4178-9952-27216af5506d" />




---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
