### PR TITLE
chore(agent): fix issue with agent alias

### DIFF
--- a/apidocs/namespaces/bedrock/interfaces/AgentAliasProps.md
+++ b/apidocs/namespaces/bedrock/interfaces/AgentAliasProps.md
@@ -41,7 +41,7 @@ The name for the agent alias.
 #### Default
 
 ```ts
-- "latest"
+- "latest-{hash}"
 ```
 
 ***

--- a/src/cdk-lib/bedrock/README.md
+++ b/src/cdk-lib/bedrock/README.md
@@ -1024,7 +1024,7 @@ agent.add_action_group(actionGroup)
 
 The `Agent` constructs take an optional parameter `shouldPrepareAgent` to indicate that the Agent should be prepared after any updates to an agent, Knowledge Base association, or action group. This may increase the time to create and update those resources. By default, this value is false .
 
-Creating an agent alias will not prepare the agent, so if you create an alias with `addAlias` or by providing an `aliasName` when creating the agent then you should set `shouldPrepareAgent` to **_true_**.
+Creating an agent alias will not prepare the agent, so if you create an alias using the `AgentAlias` resource then you should set `shouldPrepareAgent` to **_true_**.
 
 #### Prompt Overrides
 

--- a/src/cdk-lib/bedrock/agents/agent-alias.ts
+++ b/src/cdk-lib/bedrock/agents/agent-alias.ts
@@ -128,7 +128,7 @@ export interface AgentAliasProps {
   /**
    * The name for the agent alias.
    *
-   * @default - "latest"
+   * @default - "latest-{hash}"
    */
   readonly aliasName?: string;
   /**
@@ -215,14 +215,15 @@ export class AgentAlias extends AgentAliasBase {
   constructor(scope: Construct, id: string, props: AgentAliasProps) {
     super(scope, id);
 
+    // Compute hash from agent, to recreate the resource when agent has changed
+    const hash = md5hash(props.agent.agentId + props.agentVersion + props.agent.lastUpdated);
+
     // ------------------------------------------------------
     // Set properties or defaults
     // ------------------------------------------------------
-    this.aliasName = props.aliasName ?? 'latest';
+    // see https://github.com/awslabs/generative-ai-cdk-constructs/issues/947
+    this.aliasName = props.aliasName ?? `latest-${hash}`;
     this.agent = props.agent;
-
-    // Compute hash from agent, to recreate the resource when agent has changed
-    const hash = md5hash(props.agent.agentId + props.agentVersion + props.agent.lastUpdated);
 
     // ------------------------------------------------------
     // L1 Instantiation


### PR DESCRIPTION
Fixes #947 

Fix collision in default name for agent alias. Thanks to @mccauleyp.

Tested by deploying a first agent+alias, then creating a second alias:

```
const agent = new bedrock.Agent(this, 'Agent', {
      foundationModel: bedrock.BedrockFoundationModel.ANTHROPIC_CLAUDE_3_5_SONNET_V1_0,
      instruction: 'You are a helpful and friendly agent that answers questions about literature.',
      userInputEnabled: true,
      shouldPrepareAgent:true
    });

    new bedrock.AgentAlias(this, 'myalias2', {
      agent: agent,
      description: 'mytest'
    });

    new bedrock.AgentAlias(this, 'myalias3', {
      agent: agent,
      description: 'mytest2',
      agentVersion: '2'
    });
```

<img width="585" alt="Screenshot 2025-02-11 at 5 45 47 PM" src="https://github.com/user-attachments/assets/f8806310-91cf-4f39-91fc-b71db1cd1c4a" />

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
