### PR TITLE
chore(guardrails): Add support for input/output modalities in Bedrock guardrails content filter

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "@aws-cdk/integ-tests-alpha",
-      "version": "2.188.0-alpha.0",
+      "version": "2.189.0-alpha.0",
       "type": "build"
     },
     {
@@ -138,7 +138,7 @@
     },
     {
       "name": "@aws-cdk/aws-lambda-python-alpha",
-      "version": "2.188.0-alpha.0",
+      "version": "2.189.0-alpha.0",
       "type": "bundled"
     },
     {
@@ -147,7 +147,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.188.0",
+      "version": "^2.189.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -29,7 +29,7 @@ import {
 const GITHUB_USER = 'awslabs';
 const PUBLICATION_NAMESPACE = 'cdklabs';
 const PROJECT_NAME = 'generative-ai-cdk-constructs';
-const CDK_VERSION: string = '2.188.0';
+const CDK_VERSION: string = '2.189.0';
 
 function camelCaseIt(input: string): string {
   // Hypens and dashes to spaces and then CamelCase...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# CDK Generative AI Constructs V0.1.302 (2025-04-11)
+
+Based on CDK library version 2.189.0
+
 # CDK Generative AI Constructs V0.1.300 (2025-04-04)
 
 Based on CDK library version 2.188.0

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -16,7 +16,7 @@ Default output format [None]: json
 ```
 
 - [Node](https://nodejs.org/en) >= v20.9.0
-- [AWS CDK](https://github.com/aws/aws-cdk/releases/tag/v2.188.0) >= 2.188.0
+- [AWS CDK](https://github.com/aws/aws-cdk/releases/tag/v2.189.0) >= 2.189.0
 - [Python](https://www.python.org/downloads/) >=3.9
 - [Projen](https://github.com/projen/projen) >= 0.91.5
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/cli/install/) >= 1.22.19

--- a/apidocs/@cdklabs/namespaces/bedrock/README.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/README.md
@@ -30,6 +30,7 @@
 - [InferenceProfileType](enumerations/InferenceProfileType.md)
 - [KnowledgeBaseType](enumerations/KnowledgeBaseType.md)
 - [ManagedWordFilterType](enumerations/ManagedWordFilterType.md)
+- [ModalityType](enumerations/ModalityType.md)
 - [OrchestrationType](enumerations/OrchestrationType.md)
 - [ParsingModality](enumerations/ParsingModality.md)
 - [ParsingStategyType](enumerations/ParsingStategyType.md)

--- a/apidocs/@cdklabs/namespaces/bedrock/enumerations/ModalityType.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/enumerations/ModalityType.md
@@ -1,0 +1,25 @@
+[**@cdklabs/generative-ai-cdk-constructs**](../../../../README.md)
+
+***
+
+[@cdklabs/generative-ai-cdk-constructs](../../../../README.md) / [bedrock](../README.md) / ModalityType
+
+# Enumeration: ModalityType
+
+The type of modality that can be used in content filters.
+
+## Enumeration Members
+
+### IMAGE
+
+> **IMAGE**: `"IMAGE"`
+
+Image modality for content filters.
+
+***
+
+### TEXT
+
+> **TEXT**: `"TEXT"`
+
+Text modality for content filters.

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/ContentFilter.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/ContentFilter.md
@@ -10,11 +10,39 @@ Interface to declare a content filter.
 
 ## Properties
 
+### inputModalities?
+
+> `readonly` `optional` **inputModalities**: [`ModalityType`](../enumerations/ModalityType.md)[]
+
+The input modalities to apply the content filter to.
+
+#### Default
+
+```ts
+undefined - Applies to all input modalities
+```
+
+***
+
 ### inputStrength
 
 > `readonly` **inputStrength**: [`ContentFilterStrength`](../enumerations/ContentFilterStrength.md)
 
 The strength of the content filter to apply to prompts / user input.
+
+***
+
+### outputModalities?
+
+> `readonly` `optional` **outputModalities**: [`ModalityType`](../enumerations/ModalityType.md)[]
+
+The output modalities to apply the content filter to.
+
+#### Default
+
+```ts
+undefined - Applies to all output modalities
+```
 
 ***
 

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/ContentFilter.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/ContentFilter.md
@@ -19,7 +19,7 @@ The input modalities to apply the content filter to.
 #### Default
 
 ```ts
-undefined - Applies to all input modalities
+undefined - Applies to text modality
 ```
 
 ***
@@ -41,7 +41,7 @@ The output modalities to apply the content filter to.
 #### Default
 
 ```ts
-undefined - Applies to all output modalities
+undefined - Applies to text modality
 ```
 
 ***

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "devDependencies": {
     "@aws-cdk/assert": "^2.68.0",
-    "@aws-cdk/integ-tests-alpha": "2.188.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.189.0-alpha.0",
     "@commitlint/config-conventional": "^18.6.3",
     "@mrgrain/jsii-struct-builder": "^0.7.51",
     "@stylistic/eslint-plugin": "^2",
@@ -103,7 +103,7 @@
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.188.0",
+    "aws-cdk-lib": "2.189.0",
     "aws-sdk-mock": "^5.9.0",
     "commit-and-tag-version": "^12",
     "commitlint": "^18.6.1",
@@ -128,11 +128,11 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.188.0",
+    "aws-cdk-lib": "^2.189.0",
     "constructs": "^10.3.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.188.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.189.0-alpha.0",
     "cdk-nag": "^2.35.66",
     "deepmerge": "^4.3.1"
   },

--- a/src/cdk-lib/bedrock/guardrails/README.md
+++ b/src/cdk-lib/bedrock/guardrails/README.md
@@ -82,6 +82,8 @@ guardrail.addContentFilter({
   type: ContentFilterType.SEXUAL,
   inputStrength: ContentFilterStrength.HIGH,
   outputStrength: ContentFilterStrength.MEDIUM,
+  inputModalities: [ModalityType.TEXT, ModalityType.IMAGE],
+  outputModalities: [ModalityType.TEXT],
 });
 ```
 
@@ -92,6 +94,8 @@ guardrail.add_content_filter(
   type=ContentFilterType.SEXUAL,
   input_strength=ContentFilterStrength.HIGH,
   output_strength=ContentFilterStrength.MEDIUM,
+  input_modalities=[ModalityType.TEXT, ModalityType.IMAGE],
+  output_modalities=[ModalityType.TEXT],
 );
 ```
 
@@ -110,6 +114,11 @@ Available content filter strengths:
 - `LOW`: Light filtering
 - `MEDIUM`: Moderate filtering
 - `HIGH`: Strict filtering
+
+Available modality types:
+
+- `TEXT`: Text modality for content filters
+- `IMAGE`: Image modality for content filters
 
 ### Denied Topics
 

--- a/src/cdk-lib/bedrock/guardrails/guardrail-filters.ts
+++ b/src/cdk-lib/bedrock/guardrails/guardrail-filters.ts
@@ -27,6 +27,20 @@ export enum ContentFilterStrength {
 }
 
 /**
+ * The type of modality that can be used in content filters.
+ */
+export enum ModalityType {
+  /**
+   * Text modality for content filters.
+   */
+  TEXT = 'TEXT',
+  /**
+   * Image modality for content filters.
+   */
+  IMAGE = 'IMAGE',
+}
+
+/**
  * The type of harmful category usable in a content filter.
  */
 export enum ContentFilterType {
@@ -82,6 +96,16 @@ export interface ContentFilter {
    * The strength of the content filter to apply to model responses.
    */
   readonly outputStrength: ContentFilterStrength;
+  /**
+   * The input modalities to apply the content filter to.
+   * @default undefined - Applies to all input modalities
+   */
+  readonly inputModalities?: ModalityType[];
+  /**
+   * The output modalities to apply the content filter to.
+   * @default undefined - Applies to all output modalities
+   */
+  readonly outputModalities?: ModalityType[];
 }
 
 /******************************************************************************

--- a/src/cdk-lib/bedrock/guardrails/guardrail-filters.ts
+++ b/src/cdk-lib/bedrock/guardrails/guardrail-filters.ts
@@ -98,12 +98,12 @@ export interface ContentFilter {
   readonly outputStrength: ContentFilterStrength;
   /**
    * The input modalities to apply the content filter to.
-   * @default undefined - Applies to all input modalities
+   * @default undefined - Applies to text modality
    */
   readonly inputModalities?: ModalityType[];
   /**
    * The output modalities to apply the content filter to.
-   * @default undefined - Applies to all output modalities
+   * @default undefined - Applies to text modality
    */
   readonly outputModalities?: ModalityType[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,10 +38,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
-"@aws-cdk/aws-lambda-python-alpha@2.188.0-alpha.0":
-  version "2.188.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.188.0-alpha.0.tgz#228e474c4f03a71c6c6043492a61a41829e2206e"
-  integrity sha512-A4LQNTxZcIItOSEj7b8UGotxUcpFqxhnng6DjK4psjfYRk9JikEbZqaTo1aATJmktlZIE2fK2OUA2Ob5CW88Og==
+"@aws-cdk/aws-lambda-python-alpha@2.189.0-alpha.0":
+  version "2.189.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.189.0-alpha.0.tgz#f6e41cc2e8a2eeb88494d0333fd89d2ebcaae295"
+  integrity sha512-8CQTqj7jnqIgvOe3qYlYiWSgDdm8vHz+zLo+vplLDSazpwrpR14goig1WXiO26vpfqNTX0dIyFbx+NJk/A4PiQ==
 
 "@aws-cdk/cfnspec@2.68.0":
   version "2.68.0"
@@ -71,10 +71,10 @@
     string-width "^4.2.3"
     table "^6.8.1"
 
-"@aws-cdk/integ-tests-alpha@2.188.0-alpha.0":
-  version "2.188.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.188.0-alpha.0.tgz#c71adf39f8a66057cb8f21a1ffd3b7e9420b1580"
-  integrity sha512-g5EWM8pjZYQTaNIv3LYSH1TzBWcFttAC0cIG5bRubZQ/D7RNyznGz5j3HAOOPdj781BKpt6wBmvrHL+bWTYV6Q==
+"@aws-cdk/integ-tests-alpha@2.189.0-alpha.0":
+  version "2.189.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.189.0-alpha.0.tgz#bac13089c981a93af0253e01debeaec243047728"
+  integrity sha512-83j4nnflyp+vO6NzQjqvvp3glcbO7lD/xuMWQWp3m+YNi+dlas8QkaEFbLCv00XUam2CU2YpcYvPZ/GfDIspYQ==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.26.2":
   version "7.26.2"
@@ -1655,10 +1655,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.188.0:
-  version "2.188.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.188.0.tgz#d61ff9b841c1cf0eda368fd22557b8d87b562b06"
-  integrity sha512-RiAkyKHUYcpI59IXP6VP1NvO0Ph5vlqIsrz6YE8KPuGfQ0LuE5ob4Ta2ibVs/fvaGyJIZkEPw54hDrytVWrk3g==
+aws-cdk-lib@2.189.0:
+  version "2.189.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.189.0.tgz#b5964f1686215834b9f8497c131901c120355147"
+  integrity sha512-B5Uha7uRntOAyuKfU0eFtxij3ZVTzGAbetw5qaXlURa68wsWpKlU72/OyKugB6JYkhjCZkSTVVBxd1pVTosxEw==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "^2.2.229"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"


### PR DESCRIPTION
Fixes #1064 

- Upgrade base CDK version to [v2.189.0](https://github.com/aws/aws-cdk/releases/tag/v2.189.0), fixing https://github.com/awslabs/generative-ai-cdk-constructs/security/dependabot/146
- Add support for input/output modalities in Bedrock guardrails content filter

Test:

![Screenshot 2025-04-10 at 5 36 59 PM](https://github.com/user-attachments/assets/894b37ec-176b-4ebb-8435-1a6d1e3c3502)

Using the following code snippet:

```
const guardrail = new bedrock.Guardrail(this, 'bedrockGuardrails', {
      name: 'my-BedrockGuardrails',
      description: 'Legal ethical guardrails.',
    });

    guardrail.addContentFilter({
      type: ContentFilterType.SEXUAL,
      inputStrength: ContentFilterStrength.HIGH,
      outputStrength: ContentFilterStrength.MEDIUM,
      inputModalities: [ModalityType.TEXT, ModalityType.IMAGE],
      outputModalities: [ModalityType.TEXT],
    });
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
