### PR TITLE
feat(bedrock): add mistral models

### DIFF
--- a/apidocs/@cdklabs/namespaces/bedrock/classes/BedrockFoundationModel.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/classes/BedrockFoundationModel.md
@@ -321,6 +321,46 @@ The ARN of the Bedrock invokable abstraction.
 
 ***
 
+### MISTRAL\_7B\_INSTRUCT\_V0
+
+> `readonly` `static` **MISTRAL\_7B\_INSTRUCT\_V0**: `BedrockFoundationModel`
+
+*************************************************************************
+                           MISTRAL AI
+*************************************************************************
+
+***
+
+### MISTRAL\_LARGE\_2402\_V1
+
+> `readonly` `static` **MISTRAL\_LARGE\_2402\_V1**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_LARGE\_2407\_V1
+
+> `readonly` `static` **MISTRAL\_LARGE\_2407\_V1**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_MIXTRAL\_8X7B\_INSTRUCT\_V0
+
+> `readonly` `static` **MISTRAL\_MIXTRAL\_8X7B\_INSTRUCT\_V0**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_PIXTRAL\_LARGE\_2502\_V1
+
+> `readonly` `static` **MISTRAL\_PIXTRAL\_LARGE\_2502\_V1**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_SMALL\_2402\_V1
+
+> `readonly` `static` **MISTRAL\_SMALL\_2402\_V1**: `BedrockFoundationModel`
+
+***
+
 ### TITAN\_EMBED\_TEXT\_V1
 
 > `readonly` `static` **TITAN\_EMBED\_TEXT\_V1**: `BedrockFoundationModel`

--- a/apidocs/@cdklabs/namespaces/bedrock/classes/BedrockFoundationModel.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/classes/BedrockFoundationModel.md
@@ -281,6 +281,46 @@ The ARN of the Bedrock invokable abstraction.
 
 ***
 
+### MISTRAL\_7B\_INSTRUCT\_V0
+
+> `readonly` `static` **MISTRAL\_7B\_INSTRUCT\_V0**: `BedrockFoundationModel`
+
+*************************************************************************
+                           MISTRAL AI
+*************************************************************************
+
+***
+
+### MISTRAL\_LARGE\_2402\_V1
+
+> `readonly` `static` **MISTRAL\_LARGE\_2402\_V1**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_LARGE\_2407\_V1
+
+> `readonly` `static` **MISTRAL\_LARGE\_2407\_V1**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_MIXTRAL\_8X7B\_INSTRUCT\_V0
+
+> `readonly` `static` **MISTRAL\_MIXTRAL\_8X7B\_INSTRUCT\_V0**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_PIXTRAL\_LARGE\_2502\_V1
+
+> `readonly` `static` **MISTRAL\_PIXTRAL\_LARGE\_2502\_V1**: `BedrockFoundationModel`
+
+***
+
+### MISTRAL\_SMALL\_2402\_V1
+
+> `readonly` `static` **MISTRAL\_SMALL\_2402\_V1**: `BedrockFoundationModel`
+
+***
+
 ### TITAN\_EMBED\_TEXT\_V1
 
 > `readonly` `static` **TITAN\_EMBED\_TEXT\_V1**: `BedrockFoundationModel`

--- a/apidocs/@cdklabs/namespaces/bedrock/classes/BedrockFoundationModel.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/classes/BedrockFoundationModel.md
@@ -321,46 +321,6 @@ The ARN of the Bedrock invokable abstraction.
 
 ***
 
-### MISTRAL\_7B\_INSTRUCT\_V0
-
-> `readonly` `static` **MISTRAL\_7B\_INSTRUCT\_V0**: `BedrockFoundationModel`
-
-*************************************************************************
-                           MISTRAL AI
-*************************************************************************
-
-***
-
-### MISTRAL\_LARGE\_2402\_V1
-
-> `readonly` `static` **MISTRAL\_LARGE\_2402\_V1**: `BedrockFoundationModel`
-
-***
-
-### MISTRAL\_LARGE\_2407\_V1
-
-> `readonly` `static` **MISTRAL\_LARGE\_2407\_V1**: `BedrockFoundationModel`
-
-***
-
-### MISTRAL\_MIXTRAL\_8X7B\_INSTRUCT\_V0
-
-> `readonly` `static` **MISTRAL\_MIXTRAL\_8X7B\_INSTRUCT\_V0**: `BedrockFoundationModel`
-
-***
-
-### MISTRAL\_PIXTRAL\_LARGE\_2502\_V1
-
-> `readonly` `static` **MISTRAL\_PIXTRAL\_LARGE\_2502\_V1**: `BedrockFoundationModel`
-
-***
-
-### MISTRAL\_SMALL\_2402\_V1
-
-> `readonly` `static` **MISTRAL\_SMALL\_2402\_V1**: `BedrockFoundationModel`
-
-***
-
 ### TITAN\_EMBED\_TEXT\_V1
 
 > `readonly` `static` **TITAN\_EMBED\_TEXT\_V1**: `BedrockFoundationModel`

--- a/src/cdk-lib/bedrock/models.ts
+++ b/src/cdk-lib/bedrock/models.ts
@@ -281,13 +281,10 @@ export class BedrockFoundationModel implements IInvokable {
   /****************************************************************************
    *                            DEEPSEEK
    ***************************************************************************/
-  public static readonly DEEPSEEK_R1_V1 = new BedrockFoundationModel(
-    'deepseek.r1-v1:0',
-    {
-      supportsAgents: true,
-      supportsCrossRegion: true,
-    },
-  );
+  public static readonly DEEPSEEK_R1_V1 = new BedrockFoundationModel('deepseek.r1-v1:0', {
+    supportsAgents: true,
+    supportsCrossRegion: true,
+  });
 
   /****************************************************************************
    *                            META
@@ -336,6 +333,62 @@ export class BedrockFoundationModel implements IInvokable {
     'meta.llama3-3-70b-instruct-v1:0',
     {
       supportsAgents: true,
+      supportsCrossRegion: true,
+    },
+  );
+  /****************************************************************************
+   *                            MISTRAL AI
+   ***************************************************************************/
+  public static readonly MISTRAL_7B_INSTRUCT_V0 = new BedrockFoundationModel(
+    'mistral.mistral-7b-instruct-v0:2',
+    {
+      supportsAgents: true,
+      optimizedForAgents: false,
+      supportsCrossRegion: false,
+    },
+  );
+
+  public static readonly MISTRAL_MIXTRAL_8X7B_INSTRUCT_V0 = new BedrockFoundationModel(
+    'mistral.mixtral-8x7b-instruct-v0:1',
+    {
+      supportsAgents: true,
+      optimizedForAgents: false,
+      supportsCrossRegion: false,
+    },
+  );
+
+  public static readonly MISTRAL_SMALL_2402_V1 = new BedrockFoundationModel(
+    'mistral.mistral-small-2402-v1:0',
+    {
+      supportsAgents: true,
+      optimizedForAgents: false,
+      supportsCrossRegion: false,
+    },
+  );
+
+  public static readonly MISTRAL_LARGE_2402_V1 = new BedrockFoundationModel(
+    'mistral.mistral-large-2402-v1:0',
+    {
+      supportsAgents: true,
+      optimizedForAgents: false,
+      supportsCrossRegion: false,
+    },
+  );
+
+  public static readonly MISTRAL_LARGE_2407_V1 = new BedrockFoundationModel(
+    'mistral.mistral-large-2407-v1:0',
+    {
+      supportsAgents: true,
+      optimizedForAgents: false,
+      supportsCrossRegion: false,
+    },
+  );
+
+  public static readonly MISTRAL_PIXTRAL_LARGE_2502_V1 = new BedrockFoundationModel(
+    'mistral.pixtral-large-2502-v1:0',
+    {
+      supportsAgents: true,
+      optimizedForAgents: false,
       supportsCrossRegion: true,
     },
   );


### PR DESCRIPTION
Adds recently added Mistral AI models
https://aws.amazon.com/blogs/aws/aws-announces-pixtral-large-25-02-model-in-amazon-bedrock-serverless/ 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
