### PR TITLE
Update index.ts to export graph knowledge base for use

### DIFF
--- a/src/cdk-lib/bedrock/index.ts
+++ b/src/cdk-lib/bedrock/index.ts
@@ -62,6 +62,7 @@ export * from './knowledge-bases/knowledge-base';
 export * from './knowledge-bases/vector-knowledge-base';
 export * from './knowledge-bases/kendra-knowledge-base';
 export * from './knowledge-bases/supplemental-data-storage';
+export * from './knowledge-bases/graph-knowledge-base';
 
 //===================================
 // Prompts


### PR DESCRIPTION
Fixes # Graph Knowledge Base Issue
Hey, I am trying to build an application using graph rag and i was unable to access the graph rag from the package itself but i think the code is already there but not exported for me the access on the package level. It would be great if you can confirm once how can i access it. If it is still under development or i need to import differently. Please let me know, Thanks.
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
