### PR TITLE
fix(agent): update agent alias

### DIFF
--- a/src/cdk-lib/bedrock/agents/README.md
+++ b/src/cdk-lib/bedrock/agents/README.md
@@ -529,6 +529,8 @@ To deploy your agent, you need to create an alias. During alias creation, Amazon
 
 By default, the `Agent` resource does not create any aliases, and you can use the 'DRAFT' version.
 
+To create a new version for an existing alias, you can update the description of your agent alias and re-deploy.
+
 ### TypeScript
 
 ```ts

--- a/src/cdk-lib/bedrock/agents/agent-alias.ts
+++ b/src/cdk-lib/bedrock/agents/agent-alias.ts
@@ -244,7 +244,7 @@ export class AgentAlias extends AgentAliasBase {
     // ------------------------------------------------------
     // L1 Instantiation
     // ------------------------------------------------------
-    const alias = new bedrock.CfnAgentAlias(this, `MyCfnAgentAlias+${hash}`, {
+    const alias = new bedrock.CfnAgentAlias(this, 'Resource', {
       agentAliasName: this.aliasName,
       agentId: this.agent.agentId,
       description: props.description,


### PR DESCRIPTION
Fixes #969

- update the CfnAgentAlias to prevent new alias creation every deployment
- update readme to provide additional information

Testing:

```
const agent = new bedrock.Agent(this, 'Agent', {
    foundationModel: bedrock.BedrockFoundationModel.ANTHROPIC_CLAUDE_3_5_SONNET_V1_0,
    instruction: 'You are an expert in the field of literature and can provide advice on books.',
    userInputEnabled: true,
    shouldPrepareAgent:true
  });

  const agentAlias = new bedrock.AgentAlias(this, 'myalias', {
    aliasName: 'my-agent-alias',
    agent: agent,
    description: 'alias for my agent'
  });
```

- Deployed locally and confirmed the agent alias ID.

<img width="1249" alt="Screenshot 2025-05-09 at 4 10 15 PM" src="https://github.com/user-attachments/assets/71316ddc-5ea4-4960-913b-15c7ec57fa37" />


- Deployed again and confirmed that the agent alias ID had **not changed**, nor the agent version it was pointing to (as I had made no changes). 

- Made a change to the agent prompt and alias description and deployed. Confirmed that the agent alias ID had **not changed** but the version **was updated** to the new one with the changes.

<img width="1241" alt="Screenshot 2025-05-09 at 4 13 14 PM" src="https://github.com/user-attachments/assets/77d4c7ab-69c1-47dd-a7ce-d95a8aed416f" />

- Create a second alias

<img width="1247" alt="Screenshot 2025-05-09 at 4 14 47 PM" src="https://github.com/user-attachments/assets/365074b2-9341-4188-bb6b-db29dacb6660" />


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
