### PR TITLE
fix(custom-resource): force amd64 platform for images

### DIFF
--- a/src/common/helpers/custom-resource-provider-helper.ts
+++ b/src/common/helpers/custom-resource-provider-helper.ts
@@ -115,7 +115,7 @@ export function buildCustomResourceProvider(props: CRProviderProps): ICRProvider
       });
 
       const customResourceFunction = new lambda.Function(this, 'CustomResourcesFunction', {
-        code: lambda.Code.fromDockerBuild(codePath),
+        code: lambda.Code.fromDockerBuild(codePath, { platform: 'linux/amd64' }),
         handler,
         runtime,
         layers,


### PR DESCRIPTION
The custom resource is currently set to be x86 arch. The platform of the docker image should match, but this won't be the case by default if you're running on another platform (e.g. arm mac). This causes an error during synth unless you pre-emptively pull the image.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
