### PR TITLE
chore(repo): enable rosetta for doc compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ __pycache__/
 !.ort.yml
 .idea
 .vscode
+.jsii.tabl.json
 /test-reports/
 junit.xml
 /coverage/

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -102,6 +102,28 @@
         }
       ]
     },
+    "docs:compile": {
+      "name": "docs:compile",
+      "description": "Verify documentation examples are correctly compiled",
+      "steps": [
+        {
+          "say": "Synthesize project files",
+          "spawn": "default"
+        },
+        {
+          "say": "Pre-compile",
+          "spawn": "pre-compile"
+        },
+        {
+          "say": "Compile",
+          "spawn": "compile"
+        },
+        {
+          "say": "Verify documentation examples are correctly compiled",
+          "exec": "jsii-rosetta extract --strict"
+        }
+      ]
+    },
     "eject": {
       "name": "eject",
       "description": "Remove projen from the project",
@@ -908,6 +930,10 @@
       "steps": [
         {
           "exec": "npx typedoc --plugin typedoc-plugin-markdown --out apidocs --readme none --categoryOrder \"Namespaces,Classes,Interfaces,*\" --disableSources ./src/index.ts"
+        },
+        {
+          "say": "Verify documentation examples are correctly compiled",
+          "exec": "jsii-rosetta extract --strict"
         }
       ]
     },

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -51,7 +51,10 @@ npm install -g npm aws-cdk yarn projen
 
 ## Testing
 
-AWS Generative AI CDK Constructs use two types of testing: unit testing and integration testing. Unit testing targets specific aspects of a construct or one of the functions in the core library. The unit tests check that certain aspects of the results are correct. You can learn more about unit testing CDK constructs [here](https://docs.aws.amazon.com/cdk/latest/guide/testing.html) and [here](https://aws.amazon.com/blogs/developer/testing-infrastructure-with-the-aws-cloud-development-kit-cdk/).
+AWS Generative AI CDK Constructs use three types of testing: unit testing, integration testing and documentation testing. 
+
+- Unit testing targets specific aspects of a construct or one of the functions in the core library. The unit tests check that certain aspects of the results are correct. You can learn more about unit testing CDK constructs [here](https://docs.aws.amazon.com/cdk/latest/guide/testing.html) and [here](https://aws.amazon.com/blogs/developer/testing-infrastructure-with-the-aws-cloud-development-kit-cdk/).
+- Documentation tests are verifying that the code snippets present in the main README file compile. This prevents common issues where documentation examples become outdated or contain errors. For more information, please refer to the [DOCUMENTATION_TESTING](./DOCUMENTATION_TESTING.md) guide.
 
 All test files can be found in the /test directory under each construct (or core). You'll find two types of files in this directory:
 
@@ -69,9 +72,9 @@ All test files can be found in the /test directory under each construct (or core
 - Using the samples repository to test your locally changed constructs. This is also useful for development.
 
 ### Pre-req:
+
 - Download the samples repository (The official samples repository https://github.com/aws-samples/generative-ai-cdk-constructs-samples includes a collection of functional use case implementations to demonstrate the usage of AWS Generative AI CDK Constructs. These can be used in the same way as architectural patterns, and can be conceptualized as an additional "higher-level" abstraction of those patterns. Those patterns (constructs) are composed together into [stacks](https://docs.aws.amazon.com/cdk/latest/guide/stacks.html), forming a "CDK app".
 )
-
 
 ### Step 1: Building the Generative AI CDK Construct
 

--- a/DOCUMENTATION_TESTING.md
+++ b/DOCUMENTATION_TESTING.md
@@ -1,0 +1,100 @@
+# Documentation Guide
+
+This guide explains how to maintain and verify documentation for the AWS Generative AI CDK Constructs library.
+
+## Overview
+
+This project uses [jsii-rosetta](https://github.com/aws/jsii/tree/main/packages/jsii-rosetta) to ensure that all code examples in the documentation are syntactically correct and can be compiled. This prevents common issues where documentation examples become outdated or contain errors.
+
+## How It Works
+
+This library uses [jsii](https://aws.github.io/jsii/) make it polyglot. jsii allows code in any language to naturally interact with JavaScript classes. It is the technology that enables the AWS Cloud Development Kit to deliver polyglot libraries from a single codebase, like this one. A class library written in TypeScript can be used in projects authored in TypeScript or Javascript (as usual), but also in Python, Java, C# (and other languages from the .NET family), ...
+
+jsii first compiles the code written in Typescript using the standard typescript compiler (tsc) to produce the Javascript code. It then generates an [assembly file (.jsii)](https://aws.github.io/jsii/user-guides/language-support/assembly/), which is a JSON-formatted document. This file contains a lot of information about the constructs, their fields, methods and the documentation.
+
+jsii is a toolchain with multiple tools:
+
+- jsii-rosetta that transliterates code snippets (in docs) from TypeScript to target languages. We’ll come back to this one.
+- jsii-packmack generates libraries in different programming languages.
+- jsii-docgen generates the API.md file
+and more. All the tools are described in the [documentation](https://aws.github.io/jsii/overview/toolchain/)
+
+Specifically around the documentation, jsii-rosetta will use the generated assemble file (.jsii) to extract all the examples, compile them and transliterate (translate) them in all languages. If the compilation succeed, it will generate a tablet file (named .jsii.tabl.json) that will contain all the code snippets from your project in all languages.
+
+### 1. Rosetta Fixtures
+
+Rosetta fixtures are template files that provide the necessary imports and boilerplate code for examples. They are located in the `rosetta/` directory:
+
+- `default.ts-fixture`: Default template for most examples
+
+### 2. README Integration
+
+The README.md file uses special keywords to reference example files:
+
+```markdown
+typescript fixture=default
+```
+
+You can reference any fixture located in the fixture folder.
+
+## Adding New Examples
+
+### Step 1: Fixture
+
+Update the existing fixture file in the rosetta folder, or create a new one for your use case.
+
+### Step 2: Update the README
+
+References your fixture in the code snippet definition:
+
+```markdown
+typescript fixture=default
+```
+
+### Step 3: Test the Example
+
+Run the documentation verification:
+
+```bash
+yarn docs:compile
+```
+
+This will:
+
+1. Compile the TypeScript code
+2. Extract and verify all examples using jsii-rosetta
+3. Fail if any examples have compilation errors
+
+This step will also run as part of the full build (projen build).
+
+## Best Practices
+
+### 1. Keep Examples Simple
+
+Examples should demonstrate the most common use case for a construct. Complex scenarios can be documented separately.
+
+### 2. Use Appropriate Fixtures
+
+Choose the fixture that best matches your example:
+
+- Use `default.ts-fixture` for basic examples
+- Use specific fixtures (e.g., `special.ts-fixture`) for domain-specific examples
+
+### 4. Test Examples Regularly
+
+Run `projen docs:compile` before committing changes to ensure all examples compile correctly.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Import Errors**: Make sure all necessary imports are included in your fixture file
+2. **Compilation Errors**: Check that your example code is syntactically correct
+3. **Missing Fixtures**: Create appropriate fixture files for new domains
+
+### Getting Help
+
+If you encounter issues with documentation verification:
+
+1. Check the jsii-rosetta documentation: https://github.com/aws/jsii/tree/main/packages/jsii-rosetta
+2. Review the fixture files in the `rosetta/` directory

--- a/apidocs/@cdklabs/namespaces/bedrock/classes/AgentBase.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/classes/AgentBase.md
@@ -57,12 +57,6 @@ Contains methods and attributes valid for Agents either created with CDK or impo
 
 The ARN of the agent.
 
-#### Example
-
-```ts
-"arn:aws:bedrock:us-east-1:123456789012:agent/OKDSJOGKMO"
-```
-
 #### Attribute
 
 #### Implementation of
@@ -76,12 +70,6 @@ The ARN of the agent.
 > `abstract` `readonly` **agentId**: `string`
 
 The ID of the Agent.
-
-#### Example
-
-```ts
-"OKDSJOGKMO"
-```
 
 #### Attribute
 

--- a/apidocs/@cdklabs/namespaces/bedrock/classes/ConfluenceDataSource.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/classes/ConfluenceDataSource.md
@@ -68,12 +68,6 @@ The Confluence host URL or instance URL.
 
 The unique identifier of the data source.
 
-#### Example
-
-```ts
-'JHUEVXUZMU'
-```
-
 #### Overrides
 
 [`DataSourceNew`](DataSourceNew.md).[`dataSourceId`](DataSourceNew.md#datasourceid)

--- a/apidocs/@cdklabs/namespaces/bedrock/classes/CrossRegionInferenceProfile.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/classes/CrossRegionInferenceProfile.md
@@ -26,11 +26,7 @@ https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
 
 > `readonly` **inferenceProfileArn**: `string`
 
-#### Example
-
-```ts
-'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0'
-```
+Inference profile ARN
 
 #### Implementation of
 
@@ -42,11 +38,7 @@ https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
 
 > `readonly` **inferenceProfileId**: `string`
 
-#### Example
-
-```ts
-'us.anthropic.claude-3-5-sonnet-20240620-v1:0'
-```
+Inference profile ID
 
 #### Implementation of
 
@@ -78,11 +70,7 @@ This equals to the inferenceProfileArn property, useful just to implement IInvok
 
 > `readonly` **type**: [`InferenceProfileType`](../enumerations/InferenceProfileType.md)
 
-#### Example
-
-```ts
-InferenceProfileType.SYSTEM_DEFINED
-```
+Inference profile type
 
 #### Implementation of
 

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/AgentAttributes.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/AgentAttributes.md
@@ -16,12 +16,6 @@ Attributes for specifying an imported Bedrock Agent.
 
 The ARN of the agent.
 
-#### Example
-
-```ts
-"arn:aws:bedrock:us-east-1:123456789012:agent/OKDSJOGKMO"
-```
-
 #### Attribute
 
 ***
@@ -57,11 +51,5 @@ When this agent was last updated.
 > `readonly` **roleArn**: `string`
 
 The ARN of the IAM role associated to the agent.
-
-#### Example
-
-```ts
-"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-```
 
 #### Attribute

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/ConfluenceCrawlingFilters.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/ConfluenceCrawlingFilters.md
@@ -20,15 +20,6 @@ These filters allow you to include or exclude specific content based on object t
 - You can specify inclusion and exclusion patterns using regular expressions.
 - If both inclusion and exclusion patterns match a document, the exclusion takes precedence.
 
-## Example
-
-```ts
-{
- *   objectType: ConfluenceObjectType.ATTACHMENT,
- *   excludePatterns: [".*private.*\\.pdf"]
- * }
-```
-
 ## Properties
 
 ### excludePatterns?

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/ConfluenceDataSourceAssociationProps.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/ConfluenceDataSourceAssociationProps.md
@@ -67,12 +67,6 @@ ChunkingStrategy.DEFAULT
 
 The Confluence host URL or instance URL.
 
-#### Example
-
-```ts
-https://example.atlassian.net
-```
-
 ***
 
 ### contextEnrichment?

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/ConfluenceDataSourceProps.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/ConfluenceDataSourceProps.md
@@ -71,12 +71,6 @@ ChunkingStrategy.DEFAULT
 
 The Confluence host URL or instance URL.
 
-#### Example
-
-```ts
-https://example.atlassian.net
-```
-
 #### Inherited from
 
 [`ConfluenceDataSourceAssociationProps`](ConfluenceDataSourceAssociationProps.md).[`confluenceUrl`](ConfluenceDataSourceAssociationProps.md#confluenceurl)

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/IAgent.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/IAgent.md
@@ -20,12 +20,6 @@ Represents an Agent, either created with CDK or imported.
 
 The ARN of the agent.
 
-#### Example
-
-```ts
-"arn:aws:bedrock:us-east-1:123456789012:agent/OKDSJOGKMO"
-```
-
 #### Attribute
 
 ***
@@ -35,12 +29,6 @@ The ARN of the agent.
 > `readonly` **agentId**: `string`
 
 The ID of the Agent.
-
-#### Example
-
-```ts
-"OKDSJOGKMO"
-```
 
 #### Attribute
 

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/IGuardrail.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/IGuardrail.md
@@ -38,12 +38,6 @@ that might be different than the stack they were imported into.
 
 The ARN of the guardrail.
 
-#### Example
-
-```ts
-"arn:aws:bedrock:us-east-1:123456789012:guardrail/yympzo398ipq"
-```
-
 #### Attribute
 
 ***
@@ -53,12 +47,6 @@ The ARN of the guardrail.
 > `readonly` **guardrailId**: `string`
 
 The ID of the guardrail.
-
-#### Example
-
-```ts
-"yympzo398ipq"
-```
 
 #### Attribute
 

--- a/apidocs/@cdklabs/namespaces/bedrock/interfaces/RegexFilter.md
+++ b/apidocs/@cdklabs/namespaces/bedrock/interfaces/RegexFilter.md
@@ -8,16 +8,6 @@
 
 A Regular expression (regex) filter for sensitive information.
 
-## Example
-
-```ts
-const regexFilter: RegexFilter = {
-  name: "my-custom-filter",
-  action: SensitiveInfoGuardrailAction.BLOCK,
-  pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b",
-};
-```
-
 ## Properties
 
 ### action

--- a/apidocs/@cdklabs/namespaces/kendra/classes/KendraGenAiIndex.md
+++ b/apidocs/@cdklabs/namespaces/kendra/classes/KendraGenAiIndex.md
@@ -86,12 +86,6 @@ that might be different than the stack they were imported into.
 
 The Amazon Resource Name (ARN) of the index.
 
-#### Example
-
-```ts
-'arn:aws:kendra:us-east-1:123456789012:index/af04c7ea-22bc-46b7-a65e-6c21e604fc11'
-```
-
 #### Overrides
 
 [`KendraGenAiIndexBase`](KendraGenAiIndexBase.md).[`indexArn`](KendraGenAiIndexBase.md#indexarn)
@@ -103,12 +97,6 @@ The Amazon Resource Name (ARN) of the index.
 > `readonly` **indexId**: `string`
 
 The identifier of the index.
-
-#### Example
-
-```ts
-'af04c7ea-22bc-46b7-a65e-6c21e604fc11'.
-```
 
 #### Overrides
 

--- a/apidocs/@cdklabs/namespaces/kendra/classes/KendraGenAiIndexBase.md
+++ b/apidocs/@cdklabs/namespaces/kendra/classes/KendraGenAiIndexBase.md
@@ -79,12 +79,6 @@ that might be different than the stack they were imported into.
 
 The Amazon Resource Name (ARN) of the index.
 
-#### Example
-
-```ts
-'arn:aws:kendra:us-east-1:123456789012:index/af04c7ea-22bc-46b7-a65e-6c21e604fc11'
-```
-
 #### Implementation of
 
 [`IKendraGenAiIndex`](../interfaces/IKendraGenAiIndex.md).[`indexArn`](../interfaces/IKendraGenAiIndex.md#indexarn)
@@ -96,12 +90,6 @@ The Amazon Resource Name (ARN) of the index.
 > `abstract` `readonly` **indexId**: `string`
 
 The identifier of the index.
-
-#### Example
-
-```ts
-'af04c7ea-22bc-46b7-a65e-6c21e604fc11'.
-```
 
 #### Implementation of
 

--- a/apidocs/@cdklabs/namespaces/kendra/interfaces/IKendraGenAiIndex.md
+++ b/apidocs/@cdklabs/namespaces/kendra/interfaces/IKendraGenAiIndex.md
@@ -38,12 +38,6 @@ that might be different than the stack they were imported into.
 
 The Amazon Resource Name (ARN) of the index.
 
-#### Example
-
-```ts
-'arn:aws:kendra:us-east-1:123456789012:index/af04c7ea-22bc-46b7-a65e-6c21e604fc11'
-```
-
 ***
 
 ### indexId
@@ -51,12 +45,6 @@ The Amazon Resource Name (ARN) of the index.
 > `readonly` **indexId**: `string`
 
 The identifier of the index.
-
-#### Example
-
-```ts
-'af04c7ea-22bc-46b7-a65e-6c21e604fc11'.
-```
 
 ***
 

--- a/apidocs/@cdklabs/namespaces/kendra/interfaces/KendraGenAiIndexAttributes.md
+++ b/apidocs/@cdklabs/namespaces/kendra/interfaces/KendraGenAiIndexAttributes.md
@@ -16,12 +16,6 @@ Properties needed for importing an existing Kendra Index.
 
 The Id of the index.
 
-#### Example
-
-```ts
-'af04c7ea-22bc-46b7-a65e-6c21e604fc11'
-```
-
 ***
 
 ### role

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "compat": "npx projen compat",
     "compile": "npx projen compile",
     "default": "npx projen default",
+    "docs:compile": "npx projen docs:compile",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
     "generate-models-containers": "npx projen generate-models-containers",

--- a/rosetta/default-bedrock.ts-fixture
+++ b/rosetta/default-bedrock.ts-fixture
@@ -1,0 +1,29 @@
+import { Construct } from 'constructs';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import * as genaicdk from '@cdklabs/generative-ai-cdk-constructs';
+
+// Define path utilities for examples that use them
+const path = {
+  join: (...args: string[]) => args.join('/')
+};
+
+// Define __dirname for examples that use it
+const __dirname = '/example/path';
+
+// Define a stack which is used when mmultiple stacks are needed
+let stack1: cdk.Stack;
+
+class MyStack extends cdk.Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    /// here
+  }
+}

--- a/src/cdk-lib/amazonaurora/README.md
+++ b/src/cdk-lib/amazonaurora/README.md
@@ -35,26 +35,10 @@ See the [API documentation](../../../apidocs/namespaces/amazonaurora/README.md).
 
 TypeScript
 
-```ts
-import { amazonaurora, foundation_models } from '@cdklabs/generative-ai-cdk-constructs';
-
-new amazonaurora.AmazonAuroraVectorStore(stack, 'AuroraVectorStore', {
-  embeddingsModel: foundation_models.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3,
+```ts fixture=default-bedrock
+new genaicdk.amazonaurora.AmazonAuroraVectorStore(this, 'AuroraVectorStore', {
+  embeddingsModelVectorDimension: genaicdk.bedrock.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3.vectorDimensions!,
 });
-```
-
-Python
-
-```python
-
-from cdklabs.generative_ai_cdk_constructs import (
-    amazonaurora,
-    foundation_models
-)
-
-aurora = amazonaurora.AmazonAuroraVectorStore(self, 'AuroraVectorStore',
-            embeddings_model=foundation_models.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3,
-        )
 ```
 
 ## fromExistingAuroraVectorStore()
@@ -63,11 +47,8 @@ You can import your existing Aurora DB to be used as a vector DB for a knowledge
 
 TypeScript
 
-```ts
-import { amazonaurora, foundation_models, bedrock } from '@cdklabs/generative-ai-cdk-constructs';
-import * as cdk from 'aws-cdk-lib';
-
-const auroraDb = amazonaurora.AmazonAuroraVectorStore.fromExistingAuroraVectorStore(stack, 'ExistingAuroraVectorStore', {
+```ts fixture=default-bedrock
+const auroraDb = genaicdk.amazonaurora.AmazonAuroraVectorStore.fromExistingAuroraVectorStore(this, 'ExistingAuroraVectorStore', {
   clusterIdentifier: 'aurora-serverless-vector-cluster',
   databaseName: 'bedrock_vector_db',
   schemaName: 'bedrock_integration',
@@ -76,31 +57,31 @@ const auroraDb = amazonaurora.AmazonAuroraVectorStore.fromExistingAuroraVectorSt
   textField: 'chunks',
   metadataField: 'metadata',
   primaryKeyField: 'id',
-  embeddingsModelVectorDimension: bedrock.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3.vectorDimensions!,
-  vpc: cdk.aws_ec2.Vpc.fromLookup(stack, 'VPC', {
+  embeddingsModelVectorDimension: genaicdk.bedrock.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3.vectorDimensions!,
+  vpc: cdk.aws_ec2.Vpc.fromLookup(this, 'VPC', {
     vpcId: 'vpc-0c1a234567ee8bc90',
   }),
   auroraSecurityGroup: cdk.aws_ec2.SecurityGroup.fromSecurityGroupId(
-    stack,
+    this,
     'AuroraSecurityGroup',
     'sg-012456789'
   ),
   secret: cdk.aws_rds.DatabaseSecret.fromSecretCompleteArn(
-    stack,
+    this,
     'Secret',
-    cdk.Stack.of(stack).formatArn({
+    cdk.Stack.of(this).formatArn({
       service: 'secretsmanager',
       resource: 'secret',
       resourceName: 'rds-db-credentials/cluster-1234567890',
-      region: cdk.Stack.of(stack).region,
-      account: cdk.Stack.of(stack).account,
+      region: cdk.Stack.of(this).region,
+      account: cdk.Stack.of(this).account,
       arnFormat: cdk.ArnFormat.COLON_RESOURCE_NAME,
     }),
   ),
 });
 
-const kb = new bedrock.VectorKnowledgeBase(this, "KnowledgeBase", {
-  embeddingsModel: foundation_models.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3,
+const kb = new genaicdk.bedrock.VectorKnowledgeBase(this, "KnowledgeBase", {
+  embeddingsModel: genaicdk.bedrock.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3,
   vectorStore: auroraDb,
   instruction:
     "Use this knowledge base to answer questions about books. " +
@@ -109,78 +90,13 @@ const kb = new bedrock.VectorKnowledgeBase(this, "KnowledgeBase", {
 
 const docBucket = new cdk.aws_s3.Bucket(this, "DocBucket");
 
-new bedrock.S3DataSource(this, "DataSource", {
+new genaicdk.bedrock.S3DataSource(this, "DataSource", {
   bucket: docBucket,
   knowledgeBase: kb,
   dataSourceName: "books",
-  chunkingStrategy: bedrock.ChunkingStrategy.fixedSize({
+  chunkingStrategy: genaicdk.bedrock.ChunkingStrategy.fixedSize({
     maxTokens: 500,
     overlapPercentage: 20,
   }),
 });
-```
-
-Python
-```python
-from aws_cdk import (
-    aws_s3 as s3,
-    aws_rds as rds,
-    aws_ec2 as ec2,
-    Stack,
-    ArnFormat
-)
-from cdklabs.generative_ai_cdk_constructs import (
-    bedrock,
-    amazonaurora,
-    foundation_models
-)
-
-aurora_db = amazonaurora.AmazonAuroraVectorStore.from_existing_aurora_vector_store(
-    self, 'ExistingAuroraVectorStore',
-    cluster_identifier='aurora-serverless-vector-cluster',
-    database_name='bedrock_vector_db',
-    schema_name='bedrock_integration',
-    table_name='bedrock_kb',
-    vector_field='embedding',
-    text_field='chunks',
-    metadata_field='metadata',
-    primary_key_field='id',
-    embeddings_model_vector_dimension=bedrock.BedrockFoundationModel.COHERE_EMBED_ENGLISH_V3.vectorDimensions!,
-    vpc=ec2.Vpc.from_lookup(self, 'VPC', vpc_id='vpc-0c1a234567ee8bc90'),
-    aurora_security_group=ec2.SecurityGroup.from_security_group_id(
-        self,
-        'AuroraSecurityGroup',
-        'sg-01245678'
-    ),
-    secret=rds.DatabaseSecret.from_secret_complete_arn(
-        self,
-        'Secret',
-        Stack.of(self).format_arn(
-            service= 'secretsmanager',
-            resource= 'secret',
-            resource_name= 'rds-db-credentials/cluster-1234567890',
-            region= Stack.of(self).region,
-            account= Stack.of(self).account,
-            arn_format= ArnFormat.COLON_RESOURCE_NAME
-        )
-    )
-)
-
-kb = bedrock.VectorKnowledgeBase(self, 'KnowledgeBase',
-            embeddings_model= foundation_models.BedrockFoundationModel.TITAN_EMBED_TEXT_V2_1024,
-            vector_store=aurora_db,
-            instruction=  'Use this knowledge base to answer questions about books. ' +
-    'It contains the full text of novels.'
-)
-
-docBucket = s3.Bucket(self, 'DockBucket')
-
-bedrock.S3DataSource(self, 'DataSource',
-    bucket= docBucket,
-    knowledge_base=kb,
-    data_source_name='books',
-    chunking_strategy= bedrock.ChunkingStrategy.FIXED_SIZE,
-    max_tokens=500,
-    overlap_percentage=20
-)
 ```

--- a/src/cdk-lib/aurora-dsql/README.md
+++ b/src/cdk-lib/aurora-dsql/README.md
@@ -47,14 +47,14 @@ Aurora DSQL provides several configuration options to help you establish the rig
 
 ### Single region cluster
 
-```typescript
-new auroraDsql.Cluster(stack, 'TestCluster', {});
+```typescript fixture=default-bedrock
+new genaicdk.auroraDsql.Cluster(this, 'TestCluster', {});
 ```
 
 You can use tags on a cluster, for instance:
 
-```typescript
-new auroraDsql.Cluster(this, 'TestCluster', {
+```typescript fixture=default-bedrock
+new genaicdk.auroraDsql.Cluster(this, 'TestCluster', {
     tags: {
         Name: 'TestCluster',
     }
@@ -65,13 +65,13 @@ new auroraDsql.Cluster(this, 'TestCluster', {
 
 Multi-Region peered clusters provide the same resilience and connectivity as single-Region clusters. But they improve availability by offering two Regional endpoints, one in each peered cluster Region. Both endpoints of a peered cluster present a single logical database. They are available for concurrent read and write operations, and provide strong data consistency. You can build applications that run in multiple Regions at the same time for performance and resilience—and know that readers always see the same data.
 
-```typescript
+```typescript fixture=default-bedrock
 // create a cluster in a different region
-const peeredCluster1 = new auroraDsql.Cluster(stack1, 'TestPeeredCluster1', {});
+const peeredCluster1 = new genaicdk.auroraDsql.Cluster(stack1, 'TestPeeredCluster1', {});
 
 // or load existing cluster through the fromAttributes method
 
-new Cluster(stack3, 'TestCluster', {
+new genaicdk.auroraDsql.Cluster(this, 'TestCluster', {
     multiRegionProperties: {
         witnessRegion: 'us-east-1',
         clusters: [peeredCluster1],

--- a/src/cdk-lib/bedrock/agents/agent.ts
+++ b/src/cdk-lib/bedrock/agents/agent.ts
@@ -38,13 +38,11 @@ import { OrchestrationType, CustomOrchestration } from './orchestration';
 export interface IAgent extends IResource {
   /**
    * The ARN of the agent.
-   * @example "arn:aws:bedrock:us-east-1:123456789012:agent/OKDSJOGKMO"
    * @attribute
    */
   readonly agentArn: string;
   /**
    * The ID of the Agent.
-   * @example "OKDSJOGKMO"
    * @attribute
    */
   readonly agentId: string;
@@ -214,13 +212,11 @@ export interface AgentProps {
 export interface AgentAttributes {
   /**
    * The ARN of the agent.
-   * @example "arn:aws:bedrock:us-east-1:123456789012:agent/OKDSJOGKMO"
    * @attribute
    */
   readonly agentArn: string;
   /**
    * The ARN of the IAM role associated to the agent.
-   * @example "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
    * @attribute
    */
   readonly roleArn: string;

--- a/src/cdk-lib/bedrock/data-sources/confluence-data-source.ts
+++ b/src/cdk-lib/bedrock/data-sources/confluence-data-source.ts
@@ -66,11 +66,6 @@ export enum ConfluenceObjectType {
  * - You can specify inclusion and exclusion patterns using regular expressions.
  * - If both inclusion and exclusion patterns match a document, the exclusion takes precedence.
  *
- * @example
- * {
- *   objectType: ConfluenceObjectType.ATTACHMENT,
- *   excludePatterns: [".*private.*\\.pdf"]
- * }
  */
 export interface ConfluenceCrawlingFilters {
   /**
@@ -97,7 +92,6 @@ export interface ConfluenceCrawlingFilters {
 export interface ConfluenceDataSourceAssociationProps extends DataSourceAssociationProps {
   /**
    * The Confluence host URL or instance URL.
-   * @example https://example.atlassian.net
    */
   readonly confluenceUrl: string;
   /**
@@ -138,7 +132,6 @@ export class ConfluenceDataSource extends DataSourceNew {
   // ------------------------------------------------------
   /**
    * The unique identifier of the data source.
-   * @example 'JHUEVXUZMU'
    */
   public readonly dataSourceId: string;
   /**

--- a/src/cdk-lib/bedrock/guardrails/guardrail-filters.ts
+++ b/src/cdk-lib/bedrock/guardrails/guardrail-filters.ts
@@ -572,13 +572,6 @@ export interface PIIFilter {
  *****************************************************************************/
 /**
  * A Regular expression (regex) filter for sensitive information.
- *
- * @example
- * const regexFilter: RegexFilter = {
- *   name: "my-custom-filter",
- *   action: SensitiveInfoGuardrailAction.BLOCK,
- *   pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b",
- * };
  */
 export interface RegexFilter {
   /**

--- a/src/cdk-lib/bedrock/guardrails/guardrail-version.ts
+++ b/src/cdk-lib/bedrock/guardrails/guardrail-version.ts
@@ -86,12 +86,10 @@ export interface GuardrailVersionProps {
 export interface GuardrailVersionAttributes {
   /**
    * The ARN of the guardrail.
-   * @example "arn:aws:bedrock:us-east-1:123456789012:guardrail/yympzo398ipq"
    */
   readonly guardrailArn: string;
   /**
    * The ID of the guardrail version.
-   * @example "1"
    */
   readonly guardrailVersion: string;
 }

--- a/src/cdk-lib/bedrock/guardrails/guardrails.ts
+++ b/src/cdk-lib/bedrock/guardrails/guardrails.ts
@@ -30,13 +30,11 @@ import * as filters from './guardrail-filters';
 export interface IGuardrail extends IResource {
   /**
    * The ARN of the guardrail.
-   * @example "arn:aws:bedrock:us-east-1:123456789012:guardrail/yympzo398ipq"
    * @attribute
    */
   readonly guardrailArn: string;
   /**
    * The ID of the guardrail.
-   * @example "yympzo398ipq"
    * @attribute
    */
   readonly guardrailId: string;

--- a/src/cdk-lib/bedrock/inference-profiles/cross-region-inference-profile.ts
+++ b/src/cdk-lib/bedrock/inference-profiles/cross-region-inference-profile.ts
@@ -95,15 +95,15 @@ export class CrossRegionInferenceProfile implements IInvokable, IInferenceProfil
     return new CrossRegionInferenceProfile(config);
   }
   /**
-   * @example 'us.anthropic.claude-3-5-sonnet-20240620-v1:0'
+   * Inference profile ID
    */
   public readonly inferenceProfileId: string;
   /**
-   * @example 'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0'
+   * Inference profile ARN
    */
   public readonly inferenceProfileArn: string;
   /**
-   * @example InferenceProfileType.SYSTEM_DEFINED
+   * Inference profile type
    */
   public readonly type: InferenceProfileType;
   /**

--- a/src/cdk-lib/kendra/gen-ai-index.ts
+++ b/src/cdk-lib/kendra/gen-ai-index.ts
@@ -27,13 +27,11 @@ import { generatePhysicalNameV2 } from '../../common/helpers/utils';
 export interface IKendraGenAiIndex extends IResource {
   /**
    * The Amazon Resource Name (ARN) of the index.
-   * @example 'arn:aws:kendra:us-east-1:123456789012:index/af04c7ea-22bc-46b7-a65e-6c21e604fc11'
    */
   readonly indexArn: string;
 
   /**
    * The identifier of the index.
-   * @example 'af04c7ea-22bc-46b7-a65e-6c21e604fc11'.
    */
   readonly indexId: string;
 
@@ -126,7 +124,6 @@ export interface KendraGenAiIndexProps {
 export interface KendraGenAiIndexAttributes {
   /**
    * The Id of the index.
-   * @example 'af04c7ea-22bc-46b7-a65e-6c21e604fc11'
    */
   readonly indexId: string;
   /**

--- a/src/cdk-lib/mongodb-atlas/README.md
+++ b/src/cdk-lib/mongodb-atlas/README.md
@@ -27,13 +27,8 @@ The `MongoDBAtlasVectorStore` construct allows you to define a MongoDB Atlas ins
 
 ### Usage
 
-#### TypeScript
-
-```typescript
-import * as cdk from 'aws-cdk-lib';
-import { MongoDBAtlasVectorStore } from '@cdklabs/generative-ai-cdk-constructs';
-
-const vectorStore = new MongoDBAtlasVectorStore(stack, 'MyVectorStore', {
+```typescript fixture=default-bedrock
+const vectorStore = new genaicdk.mongodbAtlas.MongoDBAtlasVectorStore({
   collectionName: 'embeddings',
   credentialsSecretArn: 'arn:aws:secretsmanager:region:account:secret:secret-name',
   databaseName: 'vectordb',
@@ -46,26 +41,6 @@ const vectorStore = new MongoDBAtlasVectorStore(stack, 'MyVectorStore', {
   },
   vectorIndexName: 'vector_index'
 });
-```
-
-#### Python
-
-```python
-from cdklabs.generative_ai_cdk_constructs import MongoDBAtlasVectorStore
-
-vector_store = MongoDBAtlasVectorStore(self, 'MyVectorStore', 
-  collection_name='embeddings',
-  credentials_secret_arn='arn:aws:secretsmanager:region:account:secret:secret-name',
-  database_name='vectordb',
-  endpoint='https://your-mongodb-atlas-endpoint.mongodb.net',
-  endpoint_service_name='mongodb-atlas',
-  field_mapping=mongodb_atlas.MongoDbAtlasFieldMapping(
-        vector_field='embedding',
-        text_field='text',
-        metadata_field='metadata'
-    ),
-  vector_index_name='vector_index'
-)
 ```
 
 ### Properties

--- a/src/cdk-lib/opensearch-vectorindex/README.md
+++ b/src/cdk-lib/opensearch-vectorindex/README.md
@@ -38,20 +38,13 @@ See the [API documentation](../../../apidocs/namespaces/opensearch_vectorindex/R
 
 The `VectorIndex` resource connects to OpenSearch and creates an index suitable for use with Amazon Bedrock Knowledge Bases.
 
-TypeScript
-
-```ts
-import {
-  opensearchserverless,
-  opensearch_vectorindex,
-} from '@cdklabs/generative-ai-cdk-constructs';
-
-const vectorStore = new opensearchserverless.VectorCollection(
+```typescript fixture=default-bedrock
+const vectorStore = new genaicdk.opensearchserverless.VectorCollection(
   this,
   'VectorCollection'
 );
 
-new opensearch_vectorindex.VectorIndex(this, 'VectorIndex', {
+new genaicdk.opensearch_vectorindex.VectorIndex(this, 'VectorIndex', {
   collection: vectorStore,
   indexName: 'bedrock-knowledge-base-default-index',
   vectorField: 'bedrock-knowledge-base-default-vector',
@@ -71,54 +64,14 @@ new opensearch_vectorindex.VectorIndex(this, 'VectorIndex', {
     },
   ],
   analyzer: {
-    characterFilters: [opensearchserverless.CharacterFilterType.ICU_NORMALIZER],
-    tokenizer: opensearchserverless.TokenizerType.KUROMOJI_TOKENIZER,
+    characterFilters: [genaicdk.opensearchserverless.CharacterFilterType.ICU_NORMALIZER],
+    tokenizer: genaicdk.opensearchserverless.TokenizerType.KUROMOJI_TOKENIZER,
     tokenFilters: [
-      opensearchserverless.TokenFilterType.KUROMOJI_BASEFORM,
-      opensearchserverless.TokenFilterType.JA_STOP,
+      genaicdk.opensearchserverless.TokenFilterType.KUROMOJI_BASEFORM,
+      genaicdk.opensearchserverless.TokenFilterType.JA_STOP,
     ],
   },
 });
-```
-
-Python
-
-```python
-from cdklabs.generative_ai_cdk_constructs import (
-    opensearchserverless,
-    opensearch_vectorindex,
-)
-
-vectorCollection = opensearchserverless.VectorCollection(self, "VectorCollection")
-
-vectorIndex = opensearch_vectorindex.VectorIndex(self, "VectorIndex",
-    vector_dimensions= 1536,
-    collection=vectorCollection,
-    index_name='bedrock-knowledge-base-default-index',
-    vector_field='bedrock-knowledge-base-default-vector',
-    precision='float',
-    distance_type='l2',
-    mappings= [
-        opensearch_vectorindex.MetadataManagementFieldProps(
-            mapping_field='AMAZON_BEDROCK_TEXT_CHUNK',
-            data_type='text',
-            filterable=True
-        ),
-        opensearch_vectorindex.MetadataManagementFieldProps(
-            mapping_field='AMAZON_BEDROCK_METADATA',
-            data_type='text',
-            filterable=False
-        )
-    ],
-    analyzer=opensearchserverless.AnalyzerProps(
-        character_filters=[opensearchserverless.CharacterFilterType.ICU_NORMALIZER],
-        tokenizer=opensearchserverless.TokenizerType.KUROMOJI_TOKENIZER,
-        token_filters=[
-            opensearchserverless.TokenFilterType.KUROMOJI_BASEFORM,
-            opensearchserverless.TokenFilterType.JA_STOP,
-        ],
-    )
-)
 ```
 
 ## Default values


### PR DESCRIPTION
Fixes #

- first stepping stone for documentation improvement
- will have follow ups for each module with fixtures used in readmes code snippets and any required update

From now on, this project uses [jsii-rosetta](https://github.com/aws/jsii/tree/main/packages/jsii-rosetta) to ensure that all code examples in the documentation are syntactically correct and can be compiled. This prevents common issues where documentation examples become outdated or contain errors.

Fixed the minimum number of code snippets so the project builds, and as mentioned above will work on enabling it on all code snippets

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
