### PR TITLE
feat(deps): upgrade cdk base version

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "@aws-cdk/integ-tests-alpha",
-      "version": "2.221.0-alpha.0",
+      "version": "2.221.1-alpha.0",
       "type": "build"
     },
     {
@@ -150,7 +150,7 @@
     },
     {
       "name": "@aws-cdk/aws-lambda-python-alpha",
-      "version": "2.221.0-alpha.0",
+      "version": "2.221.1-alpha.0",
       "type": "bundled"
     },
     {
@@ -159,7 +159,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.221.0",
+      "version": "^2.221.1",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -29,7 +29,7 @@ import {
 const GITHUB_USER = 'awslabs';
 const PUBLICATION_NAMESPACE = 'cdklabs';
 const PROJECT_NAME = 'generative-ai-cdk-constructs';
-const CDK_VERSION: string = '2.221.0';
+const CDK_VERSION: string = '2.221.1';
 
 function camelCaseIt(input: string): string {
   // Hypens and dashes to spaces and then CamelCase...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# CDK Generative AI Constructs v0.1.312 (2025-10-30)
+
+Based on CDK library version 2.221.1
+
 # CDK Generative AI Constructs v0.1.310 (2025-10-10)
 
 Based on CDK library version 2.219.0

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -16,7 +16,7 @@ Default output format [None]: json
 ```
 
 - [Node](https://nodejs.org/en) >= v22.0.0
-- [AWS CDK](https://github.com/aws/aws-cdk/releases/tag/v2.219.0) >= 2.219.0
+- [AWS CDK](https://github.com/aws/aws-cdk/releases/tag/v2.221.1) >= 2.221.1
 - [Python](https://www.python.org/downloads/) >=3.9
 - [Projen](https://github.com/projen/projen/releases/tag/v0.98.0) >= 0.98.0
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/cli/install/) >= 1.22.19

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@aws-cdk/assert": "^2.68.0",
-    "@aws-cdk/integ-tests-alpha": "2.221.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "2.221.1-alpha.0",
     "@cdklabs/eslint-plugin": "^1.3.5",
     "@commitlint/config-conventional": "^18.6.3",
     "@mrgrain/jsii-struct-builder": "^0.7.64",
@@ -105,7 +105,7 @@
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.221.0",
+    "aws-cdk-lib": "2.221.1",
     "aws-sdk-mock": "^5.9.0",
     "commit-and-tag-version": "^12",
     "commitlint": "^18.6.1",
@@ -132,11 +132,11 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.221.0",
+    "aws-cdk-lib": "^2.221.1",
     "constructs": "^10.3.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.221.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.221.1-alpha.0",
     "cdk-nag": "^2.37.55",
     "deepmerge": "^4.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
   integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
-"@aws-cdk/aws-lambda-python-alpha@2.221.0-alpha.0":
-  version "2.221.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.221.0-alpha.0.tgz#5db232993c9cd1d0347dfd43748710bf9b862376"
-  integrity sha512-LpygiNcK8VbkWmAM45fZNRNUNRNvCBoR37xJc6vZF76807UvaTipblIqroOkaOZqcu5CHT0iEs4pe7Yrk6myMg==
+"@aws-cdk/aws-lambda-python-alpha@2.221.1-alpha.0":
+  version "2.221.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.221.1-alpha.0.tgz#5de6cc2783ec329c7baa57375c1b841715227241"
+  integrity sha512-c6xYQWmPZDdprkRQQyBDJ7/f9gYi+JBzbH/j2cyhh/Vt9KtNXcADbq4ILPFHlcZusPKmggW2pTMNUUUmH+xFug==
 
 "@aws-cdk/cfnspec@2.68.0":
   version "2.68.0"
@@ -63,10 +63,10 @@
     string-width "^4.2.3"
     table "^6.8.1"
 
-"@aws-cdk/integ-tests-alpha@2.221.0-alpha.0":
-  version "2.221.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.221.0-alpha.0.tgz#d387a5a430a525f6be6804e4f68c5d586ef59912"
-  integrity sha512-ccLfDK0ph2z9IEL59I8L2L20woKhE9ku/ZrIqtPLFvB+x1HkUf9Z4nqKuCnYQdPMxRJ2/OFFn3DNqbmomMeyRA==
+"@aws-cdk/integ-tests-alpha@2.221.1-alpha.0":
+  version "2.221.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.221.1-alpha.0.tgz#c6a4c43b1512317cd4954503fa6c56f67d99b4a3"
+  integrity sha512-HCaplhEpv+Qe9cEvbRSFQx/HGL64Ftb5aYHCB4++RNUhL60mjkeRJRxSSW55dlOojLz7UBEzTkKKGo+CBnpsFA==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"
@@ -1725,10 +1725,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.221.0:
-  version "2.221.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.221.0.tgz#4af28bcaca7464248ed34ef0082158c460bf53ab"
-  integrity sha512-lOS0EnE4NQBW2+/0/qxwDBtGYGt8Fa/lCYsvC2/XTU3vBZ454mKkdI9zWKspZJ+Fo5b2iS1Q7iiSIbQVat2xJA==
+aws-cdk-lib@2.221.1:
+  version "2.221.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.221.1.tgz#a0ad94ab915b2ab1b43235c58af56cb5f1dd1baa"
+  integrity sha512-QHlfxB54sCIBXYRrGfMacXSbTUdUmc4KSJtbUTa3SU4HA884Mn2yvLHupCXbbOUfCtu5tIm/q7BX0JwYC4kuwg==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "2.2.242"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"


### PR DESCRIPTION
Fixes #

Upgrade the cdk version due to an issue in go compilation introduced in v221, see https://github.com/aws/aws-cdk/releases/tag/v2.221.1 release notes

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
