### PR TITLE
chore: update max node version

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -79,7 +79,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   bundledDeps: ['deepmerge', `@aws-cdk/aws-lambda-python-alpha@${CDK_VERSION}-alpha.0`],
   // Keep synchronized with https://github.com/nodejs/release#release-schedule
   minNodeVersion: '20.x', // 'MAINTENANCE' (first LTS)
-  maxNodeVersion: '24.x', // 'CURRENT'
+  maxNodeVersion: '25.x', // 'CURRENT'
   workflowNodeVersion: '22.x', // 'ACTIVE'
 
   npmTokenSecret: 'NPM_TOKEN',

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "generative-ai"
   ],
   "engines": {
-    "node": ">= 20.x <= 24.x"
+    "node": ">= 20.x <= 25.x"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes https://github.com/awslabs/generative-ai-cdk-constructs/issues/1311

The current node version as of 4/26/26 is Node 25.x. This bumps the projen config. It should be noted that Node 26.x will be current in May so this will need to be updated again then.

<img width="853" height="795" alt="image" src="https://github.com/user-attachments/assets/295971ff-447f-4406-bc69-bb247d42e388" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
