### PR TITLE
feat(custom-resources): remove Docker build dependency from build phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,4 +150,6 @@ test/patterns/gen-ai/aws-aoss-cw-dashboard/integ-tests/aws-aoss-cw-dashboard.int
 !/.github/workflows/code-generation.yml
 test/**/*.integ.snapshot/*.metadata.json
 test/**/*.integ.snapshot/**/*.metadata.json
+lambda/**/dist/
+lambda/**/poetry.lock
 !/.projenrc.ts

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -593,6 +593,8 @@ for (const task of project.tasks.all) {
 project.gitignore.addPatterns(
   'test/**/*.integ.snapshot/*.metadata.json',
   'test/**/*.integ.snapshot/**/*.metadata.json',
+  'lambda/**/dist/',
+  'lambda/**/poetry.lock',
 );
 
 project.synth();

--- a/src/common/helpers/custom-resource-provider-helper.ts
+++ b/src/common/helpers/custom-resource-provider-helper.ts
@@ -11,6 +11,7 @@
  *  and limitations under the License.
  */
 
+import * as child_process from 'child_process';
 import * as cdk from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -29,7 +30,8 @@ export interface CRProviderProps {
   readonly providerName: string;
 
   /**
-   * Path to custom resource provider Lambda code. The package will be built using lambda.Code.fromDockerBuild().
+   * Path to custom resource provider Lambda code. The package will be bundled locally if
+   * pip/poetry are available, otherwise falls back to Docker.
    *
    * @default - None.
    */
@@ -114,7 +116,32 @@ export function buildCustomResourceProvider(props: CRProviderProps): ICRProvider
       });
 
       const customResourceFunction = new lambda.Function(this, 'CustomResourcesFunction', {
-        code: lambda.Code.fromDockerBuild(codePath),
+        code: lambda.Code.fromAsset(codePath, {
+          bundling: {
+            image: runtime.bundlingImage,
+            user: 'root',
+            command: [
+              'bash', '-c',
+              'pip install poetry -q && poetry install -q && poetry build -q && poetry run pip install --upgrade -t /asset-output dist/*.whl -q',
+            ],
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const opts = { cwd: codePath, stdio: 'pipe' as const, shell: true };
+                  const steps = [
+                    () => child_process.spawnSync('pip', ['install', 'poetry', '-q'], opts),
+                    () => child_process.spawnSync('poetry', ['install', '-q'], opts),
+                    () => child_process.spawnSync('poetry', ['build', '-q'], opts),
+                    () => child_process.spawnSync('poetry', ['run', 'pip', 'install', '--upgrade', '-t', outputDir, 'dist/*.whl', '-q'], opts),
+                  ];
+                  return steps.every(step => step().status === 0);
+                } catch {
+                  return false;
+                }
+              },
+            },
+          },
+        }),
         handler,
         runtime,
         layers,

--- a/test/common/helpers/custom-resource-provider-helper.test.ts
+++ b/test/common/helpers/custom-resource-provider-helper.test.ts
@@ -11,11 +11,28 @@
  *  and limitations under the License.
  */
 
+import * as child_process from 'child_process';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { buildCustomResourceProvider } from '../../../src/common/helpers/custom-resource-provider-helper';
+
+jest.mock('child_process', () => ({
+  spawnSync: jest.fn().mockImplementation((_cmd: string, _args: string[]) => {
+    // Extract outputDir from the args to write a dummy file for CDK's AssetStaging
+    if (_args?.includes('--upgrade')) {
+      const tIdx = _args.indexOf('-t');
+      if (tIdx !== -1) {
+        const outputDir = _args[tIdx + 1];
+        fs.mkdirSync(outputDir, { recursive: true });
+        fs.writeFileSync(path.join(outputDir, 'dummy.py'), '# bundled');
+      }
+    }
+    return { status: 0 };
+  }),
+}));
 
 const AOSSCRProvider = buildCustomResourceProvider({
   providerName: 'OpenSearchIndexCRProvider',
@@ -34,5 +51,59 @@ describe('Custom Resource Provider', () => {
       Handler: 'custom_resources.on_event',
       Runtime: 'python3.13',
     });
+  });
+
+  test('Local bundling calls spawnSync with poetry commands', () => {
+    const stack = new cdk.Stack();
+    AOSSCRProvider.getProvider(stack);
+    expect(child_process.spawnSync).toHaveBeenCalledWith(
+      'poetry',
+      expect.arrayContaining(['install']),
+      expect.objectContaining({ cwd: expect.stringContaining('opensearch-serverless-custom-resources'), shell: true }),
+    );
+  });
+
+  test('Local bundling returns false when spawnSync fails', () => {
+    // Mock spawnSync to simulate poetry/pip not being available
+    (child_process.spawnSync as jest.Mock).mockReturnValueOnce({ status: 1 });
+
+    const FailProvider = buildCustomResourceProvider({
+      providerName: 'FailCRProvider',
+      codePath: path.join(__dirname, '../../../lambda/opensearch-serverless-custom-resources'),
+      handler: 'custom_resources.on_event',
+      runtime: lambda.Runtime.PYTHON_3_13,
+    });
+
+    // tryBundle returns false (status !== 0), CDK falls back to Docker which fails in test env
+    const stack = new cdk.Stack();
+    expect(() => FailProvider.getProvider(stack)).toThrow();
+    // Verify the local bundling poetry command was attempted
+    expect((child_process.spawnSync as jest.Mock).mock.calls).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([
+          'pip',
+          expect.arrayContaining(['install', 'poetry']),
+          expect.objectContaining({ cwd: expect.stringContaining('opensearch-serverless-custom-resources'), shell: true }),
+        ]),
+      ]),
+    );
+  });
+
+  test('Local bundling returns false when spawnSync throws an exception', () => {
+    // Mock spawnSync to throw (e.g. bash not found)
+    (child_process.spawnSync as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('ENOENT: bash not found');
+    });
+
+    const ThrowProvider = buildCustomResourceProvider({
+      providerName: 'ThrowCRProvider',
+      codePath: path.join(__dirname, '../../../lambda/opensearch-serverless-custom-resources'),
+      handler: 'custom_resources.on_event',
+      runtime: lambda.Runtime.PYTHON_3_13,
+    });
+
+    // tryBundle catches the exception and returns false, CDK falls back to Docker which fails
+    const stack = new cdk.Stack();
+    expect(() => ThrowProvider.getProvider(stack)).toThrow();
   });
 });


### PR DESCRIPTION
Fixes #567

Replaces `lambda.Code.fromDockerBuild()` with `lambda.Code.fromAsset()` using local bundling with Docker fallback in the shared `buildCustomResourceProvider` helper.

### Changes
- Local bundling tries `pip/poetry` first (no Docker needed if Python tooling is available)
- Falls back to Docker bundling if local bundling fails
- Added `user: 'root'` to Docker bundling to fix permission issues with CDK's default user mapping

### Affected constructs
- OpenSearch Serverless Vector Index
- Amazon Aurora PgVector

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
