### PR TITLE
chore(codegen): align model/DLC generators with eslint formatting

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -229,6 +229,10 @@
           "exec": "npm run generate"
         },
         {
+          "say": "Lint-fix generated model and DLC source files",
+          "exec": "npx eslint --fix src/patterns/gen-ai/aws-model-deployment-sagemaker/deep-learning-container-image.ts src/patterns/gen-ai/aws-model-deployment-sagemaker/jumpstart-model.ts"
+        },
+        {
           "say": "Generate the new apidocs",
           "spawn": "post-compile"
         }

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -530,6 +530,12 @@ project.addTask('generate-models-containers', {
       exec: 'npm run generate',
     },
     {
+      // Keep generated sources aligned with eslint so code-generation PRs
+      // do not open with formatting-only diffs that self-mutation later reverts.
+      say: 'Lint-fix generated model and DLC source files',
+      exec: 'npx eslint --fix src/patterns/gen-ai/aws-model-deployment-sagemaker/deep-learning-container-image.ts src/patterns/gen-ai/aws-model-deployment-sagemaker/jumpstart-model.ts',
+    },
+    {
       say: 'Generate the new apidocs',
       spawn: 'post-compile',
     },

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/code-generation/generate-dlc-container-images.ts
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/code-generation/generate-dlc-container-images.ts
@@ -189,7 +189,7 @@ import { Construct } from 'constructs';
 import { ContainerImage, ContainerImageConfig } from './container-image';
 
 export class DeepLearningContainerImage extends ContainerImage {
-${imagesStr}
+${imagesStr.trimEnd()}
 
   public static fromDeepLearningContainerImage(
     repositoryName: string,

--- a/src/patterns/gen-ai/aws-model-deployment-sagemaker/code-generation/generate-jumpstart-models.ts
+++ b/src/patterns/gen-ai/aws-model-deployment-sagemaker/code-generation/generate-jumpstart-models.ts
@@ -291,7 +291,7 @@ export interface IJumpStartModelSpec {
 }
 
 export class JumpStartModel {
-${modelsStr}
+${modelsStr.trimEnd()}
 
   public static of(name: string): JumpStartModel {
     return new JumpStartModel(name);
@@ -307,7 +307,8 @@ ${modelsStr}
 
     return json[this.name];
   }
-}`;
+}
+`;
 
   GenerateUtils.writeFileSyncWithDirs(
     JUMPSTART_MODELS_PATH,


### PR DESCRIPTION
Fixes empty code-generation PRs such as https://github.com/awslabs/generative-ai-cdk-constructs/pull/1392

## Summary

Automated model/DLC upgrade PRs sometimes open with only formatting diffs.
The build self-mutation then reverts those diffs, leaving a PR with 0 changes.

Root cause: the codegen templates in
`generate-dlc-container-images.ts` and `generate-jumpstart-models.ts` were
out of sync with eslint rules:

- Extra blank line before the next class method (`${membersStr}` already ends
  with `\n`, and the template also inserts a blank line)
- Missing trailing newline in `jumpstart-model.ts` (`eol-last: always`)

## Changes

- Use `${imagesStr.trimEnd()}` / `${modelsStr.trimEnd()}` so generated files
  have exactly one blank line before subsequent class members
- Ensure JumpStart generated source ends with a newline
- Run `eslint --fix` on the generated `.ts` files after codegen as a
  safety net against future lint drift

## Pull Request Checklist

* [x] Testing
  - Unit test added (prefer not to modify an existing test, otherwise, it's probably a breaking change)
  - Integration test added (if adding a new pattern or making a significant update to an existing pattern)
* [x] Docs
  - __README__: README and/or documentation topic updated
  - __Design__: For significant features, design document added to `design` folder
* [x] Title and Description
  - __Change type__: title prefixed with **fix**, **feat** or **chore** and module name in parenthesis, which will appear in changelog
  - __Title__: use lower-case and doesn't end with a period
  - __Breaking?__: last paragraph: "BREAKING CHANGE: <describe what changed + link for details>"
  - __Issues__: Indicate issues fixed via: "**Fixes #xxx**" or "**Closes #xxx**"

## Test plan

- [x] Confirmed on [PR #1392](https://github.com/awslabs/generative-ai-cdk-constructs/pull/1392): initial commit only added blank lines / removed EOF newline; self-mutation exactly reversed those
- [x] Simulated old vs new template output: blank lines before method go from 2 → 1; JumpStart EOF newline restored
- [x] Regenerated `.projen/tasks.json` via `npx projen default`
- [ ] CI build on GitHub Actions

## Notes

Internal tooling only (`chore`); no construct API or package consumer impact.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.

Made with [Cursor](https://cursor.com)